### PR TITLE
Add Terraform IaC for all bot infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,25 +3,29 @@ name: Deploy Telegram Bot to Lambda
 on:
   push:
     branches:
-      - main
+      - master
+    paths-ignore:
+      - 'infra/**'
+      - '*.md'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'infra/**'
+      - '*.md'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout code
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 2. Setup Python
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'  # match your Lambda 
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |
@@ -31,47 +35,37 @@ jobs:
 
       - name: Lint code with flake8
         run: |
-          echo "Running flake8..."
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # Optional: exit-zero allows warnings but not errors
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
 
       - name: Run unit tests
         run: |
-          echo "Running pytest..."
           pytest --maxfail=1 --disable-warnings -q
 
-      # 3. Install dependencies into package folder
-      - name: Install dependencies
+      - name: Install dependencies into package
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt -t package/
 
-      # 4. Copy bot code into package folder
       - name: Copy bot files
         run: |
           cp -r src/ package/
 
-      # 5. Zip the package
       - name: Package Lambda function
         run: |
           cd package
           zip -r ../function.zip .
-          cd ..
 
-      # 6. Configure AWS credentials
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        if: github.event_name == 'push'
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-north-1   
+          aws-region: eu-north-1
 
-      # 7. Deploy to Lambda
       - name: Deploy Lambda
+        if: github.event_name == 'push'
         run: |
           aws lambda update-function-code \
             --function-name drahmsstrasseTelegramBot \
             --zip-file fileb://function.zip
-
-

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,105 @@
+name: Terraform Infrastructure
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'infra/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'infra/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-north-1
+
+      - name: Bootstrap S3 backend and DynamoDB lock table
+        working-directory: .
+        run: |
+          aws s3api head-bucket --bucket drahmstrassebot-tfstate 2>/dev/null || \
+            aws s3api create-bucket --bucket drahmstrassebot-tfstate \
+              --region eu-north-1 \
+              --create-bucket-configuration LocationConstraint=eu-north-1
+          aws s3api put-bucket-versioning --bucket drahmstrassebot-tfstate \
+            --versioning-configuration Status=Enabled
+          aws s3api put-bucket-encryption --bucket drahmstrassebot-tfstate \
+            --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+          aws s3api put-public-access-block --bucket drahmstrassebot-tfstate \
+            --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+          aws dynamodb describe-table --table-name drahmstrassebot-tflock 2>/dev/null || \
+            aws dynamodb create-table --table-name drahmstrassebot-tflock \
+              --attribute-definitions AttributeName=LockID,AttributeType=S \
+              --key-schema AttributeName=LockID,KeyType=HASH \
+              --billing-mode PAY_PER_REQUEST
+
+      - name: Create dummy zip for Lambda
+        run: |
+          echo "placeholder" > dummy.txt
+          zip dummy.zip dummy.txt
+          rm dummy.txt
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -no-color \
+            -var="bot_chat_id=${{ secrets.BOT_CHAT_ID }}" \
+            -var="telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
+            -out=tfplan
+        continue-on-error: true
+
+      - name: Comment PR with plan
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan \`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: terraform apply -auto-approve tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,13 @@ bugs/
 nohup.out
 bot.log
 .venv
+
+# Terraform
+infra/.terraform/
+infra/*.tfstate
+infra/*.tfstate.backup
+infra/.terraform.lock.hcl
+infra/terraform.tfvars
+infra/dummy.zip
+infra/bootstrap/terraform.tfstate*
+infra/bootstrap/.terraform/

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -1,0 +1,24 @@
+resource "aws_apigatewayv2_api" "webhook" {
+  name          = "drahmstrassebot-webhook"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.webhook.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.webhook.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.bot.invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "webhook" {
+  api_id    = aws_apigatewayv2_api.webhook.id
+  route_key = "POST /webhook"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-north-1"
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "drahmstrassebot-tfstate"
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "tflock" {
+  name         = "drahmstrassebot-tflock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -1,0 +1,84 @@
+locals {
+  prod_chat_id = "-1001633433047"
+
+  schedules = {
+    whoishere = {
+      schedule    = "cron(0 15 ? * MON-FRI *)"
+      description = "Ask who is home for dinner (weekdays 15:00 UTC)"
+      command     = "/whoishere@DrahmstrasseBot"
+    }
+    roles = {
+      schedule    = "cron(0 8 ? * MON *)"
+      description = "Assign weekly chore roles (Monday 08:00 UTC)"
+      command     = "/roles"
+    }
+    papier = {
+      schedule    = "cron(0 19 ? * MON *)"
+      description = "Paper/cardboard reminder (Monday 19:00 UTC)"
+      command     = "/papier@DrahmstrasseBot"
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "whoishere" {
+  name                = "whoishere"
+  description         = local.schedules.whoishere.description
+  schedule_expression = local.schedules.whoishere.schedule
+}
+
+resource "aws_cloudwatch_event_target" "whoishere" {
+  rule = aws_cloudwatch_event_rule.whoishere.name
+  arn  = aws_lambda_function.bot.arn
+
+  input = jsonencode({
+    body = jsonencode({
+      message = {
+        chat = { id = tonumber(local.prod_chat_id) }
+        text = local.schedules.whoishere.command
+        entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.whoishere.command) }]
+      }
+    })
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "roles" {
+  name                = "roles"
+  description         = local.schedules.roles.description
+  schedule_expression = local.schedules.roles.schedule
+}
+
+resource "aws_cloudwatch_event_target" "roles" {
+  rule = aws_cloudwatch_event_rule.roles.name
+  arn  = aws_lambda_function.bot.arn
+
+  input = jsonencode({
+    body = jsonencode({
+      message = {
+        chat = { id = tonumber(local.prod_chat_id) }
+        text = local.schedules.roles.command
+        entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.roles.command) }]
+      }
+    })
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "papier" {
+  name                = "papier"
+  description         = local.schedules.papier.description
+  schedule_expression = local.schedules.papier.schedule
+}
+
+resource "aws_cloudwatch_event_target" "papier" {
+  rule = aws_cloudwatch_event_rule.papier.name
+  arn  = aws_lambda_function.bot.arn
+
+  input = jsonencode({
+    body = jsonencode({
+      message = {
+        chat = { id = tonumber(local.prod_chat_id) }
+        text = local.schedules.papier.command
+        entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.papier.command) }]
+      }
+    })
+  })
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "drahmsstrasseTelegramBot-role-4xqq5pf3"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "ssm_read" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [aws_ssm_parameter.telegram_token.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "ssm_read" {
+  name   = "ssm-read-telegram-token"
+  role   = aws_iam_role.lambda_role.id
+  policy = data.aws_iam_policy_document.ssm_read.json
+}

--- a/infra/imports.tf
+++ b/infra/imports.tf
@@ -1,0 +1,43 @@
+# Temporary import blocks — remove after first successful `terraform apply`
+
+import {
+  to = aws_lambda_function.bot
+  id = "drahmsstrasseTelegramBot"
+}
+
+import {
+  to = aws_iam_role.lambda_role
+  id = "drahmsstrasseTelegramBot-role-4xqq5pf3"
+}
+
+import {
+  to = aws_cloudwatch_event_rule.whoishere
+  id = "whoishere"
+}
+
+import {
+  to = aws_cloudwatch_event_rule.roles
+  id = "roles"
+}
+
+import {
+  to = aws_cloudwatch_event_rule.papier
+  id = "papier"
+}
+
+import {
+  to = aws_cloudwatch_event_target.whoishere
+  id = "whoishere/4yb8lsapzf0so8ua5oif"
+}
+
+import {
+  to = aws_cloudwatch_event_target.roles
+  id = "roles/ctare3ag5n26f1jbbna"
+}
+
+import {
+  to = aws_cloudwatch_event_target.papier
+  id = "papier/st9ip73rj8i97ngvihc"
+}
+
+# API Gateway will be created fresh (no existing HTTP API found to import)

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,56 @@
+resource "aws_lambda_function" "bot" {
+  function_name = var.lambda_function_name
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "src.main.lambda_handler"
+  runtime       = "python3.12"
+  architectures = ["x86_64"]
+  memory_size   = 128
+  timeout       = 3
+
+  filename = "dummy.zip"
+
+  environment {
+    variables = {
+      TELEGRAM_TOKEN = var.telegram_token
+      BOT_CHAT_ID    = var.bot_chat_id
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [filename, source_code_hash, last_modified]
+  }
+}
+
+# Allow API Gateway to invoke the Lambda
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bot.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
+}
+
+# Allow EventBridge rules to invoke the Lambda
+resource "aws_lambda_permission" "eventbridge_whoishere" {
+  statement_id  = "AllowEventBridgeWhoishere"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bot.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.whoishere.arn
+}
+
+resource "aws_lambda_permission" "eventbridge_roles" {
+  statement_id  = "AllowEventBridgeRoles"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bot.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.roles.arn
+}
+
+resource "aws_lambda_permission" "eventbridge_papier" {
+  statement_id  = "AllowEventBridgePapier"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bot.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.papier.arn
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "drahmstrassebot-tfstate"
+    key            = "infra/terraform.tfstate"
+    region         = "eu-north-1"
+    dynamodb_table = "drahmstrassebot-tflock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "webhook_url" {
+  description = "API Gateway webhook URL for Telegram"
+  value       = "${aws_apigatewayv2_stage.default.invoke_url}/webhook"
+}
+
+output "lambda_arn" {
+  description = "Lambda function ARN"
+  value       = aws_lambda_function.bot.arn
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name"
+  value       = aws_lambda_function.bot.function_name
+}
+
+output "ssm_parameter_name" {
+  description = "SSM parameter name for the Telegram token"
+  value       = aws_ssm_parameter.telegram_token.name
+}

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -1,0 +1,9 @@
+resource "aws_ssm_parameter" "telegram_token" {
+  name  = "/drahmstrassebot/telegram-token"
+  type  = "SecureString"
+  value = var.telegram_token
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "lambda_function_name" {
+  description = "Name of the Lambda function"
+  type        = string
+  default     = "drahmsstrasseTelegramBot"
+}
+
+variable "bot_chat_id" {
+  description = "Telegram group chat ID"
+  type        = string
+}
+
+variable "telegram_token" {
+  description = "Telegram bot API token"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Summary

  - Add Terraform to manage all bot infrastructure as code
  (Lambda, API Gateway, EventBridge rules, IAM role, SSM
  parameter)
  - Bootstrap S3 backend + DynamoDB lock table directly in CI
  (no local Terraform needed)
  - Add infra.yml workflow: plan on PRs, apply on push to master
  - Update deploy.yml: fix branch trigger (main → master), bump
  actions to v4/v5, Python 3.11 → 3.12, add paths-ignore for
  infra/**
  - Include import blocks for existing AWS resources (Lambda,
  IAM role, 3 EventBridge rules + targets)
  - API Gateway will be created fresh (existing one not found in
   AWS console)

  # Test plan

  - Verify infra.yml workflow runs and bootstrap creates S3
  bucket + DynamoDB table
  - Verify terraform plan succeeds with import blocks
  - Merge and verify terraform apply imports existing resources
  without destructive changes
  - Run terraform plan post-apply — should show no changes
  (except new API Gateway + SSM)
  - Test bot commands (/roles, /papier, /whoishere) still work
  after apply
  - Remove imports.tf in a follow-up PR after successful import