### PR TITLE
 Add post-deploy smoke test for EventBridge payload deserialization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,3 +74,34 @@ jobs:
           aws lambda update-function-code \
             --function-name drahmsstrasseTelegramBot \
             --zip-file fileb://function.zip
+
+      - name: Wait for Lambda update
+        if: github.event_name == 'push'
+        run: aws lambda wait function-updated --function-name drahmsstrasseTelegramBot
+
+      - name: Smoke test EventBridge payload
+        if: github.event_name == 'push'
+        run: |
+          PAYLOAD='{"body":"{\"message\":{\"chat\":{\"id\":-4867763410},\"text\":\"/lessive\",\"entities\":[{\"type\":\"bot_command\",\"offset\":0,\"length\":8}]}}"}'
+
+          RESPONSE=$(aws lambda invoke \
+            --function-name drahmsstrasseTelegramBot \
+            --payload "$PAYLOAD" \
+            --log-type Tail \
+            --cli-binary-format raw-in-base64-out \
+            /dev/stdout 2>/dev/null)
+
+          LOG_RESULT=$(echo "$RESPONSE" | grep -o '"LogResult": "[^"]*"' | cut -d'"' -f4)
+          LOGS=$(echo "$LOG_RESULT" | base64 --decode)
+
+          echo "=== Lambda Logs ==="
+          echo "$LOGS"
+          echo "==================="
+
+          if echo "$LOGS" | grep -q "Telebot deserialization succeeded"; then
+            echo "Smoke test PASSED"
+          else
+            echo "Smoke test FAILED: EventBridge payload deserialization failed"
+            echo "Check src/main.py field injection against current telebot requirements."
+            exit 1
+          fi

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -175,5 +175,6 @@ class Drahmbot:
         """Process a single update (for testing or Lambda)."""
         logger.info("Processing update: %s", update_json)
         update = telebot.types.Update.de_json(update_json)
+        logger.info("Telebot deserialization succeeded")
         await self.bot.process_new_updates([update])
         logger.info("Update processed successfully")


### PR DESCRIPTION

 ## Summary

  - Invoke the Lambda after deploy with an EventBridge-shaped /lessive payload to verify telebot deserialization succeeds
  - Wait for Lambda update to complete before invoking to avoid testing stale code
  - Add explicit deserialization success log line as a reliable signal for the smoke test

  ## Context

  EventBridge payloads are minimal and lack fields telebot requires (e.g. chat.type broke us in #22). These failures only surface at
  runtime when scheduled commands fire. This smoke test catches them at deploy time.

  ## Test plan

  - Push to master and verify the "Smoke test EventBridge payload" step passes in CI
  - Confirm dev chat receives a /lessive message after deploy
  - Verify the pipeline fails if the log check doesn't find the success marker (can test locally by removing a setdefault call)