### PR TITLE
feat: add Timon's ID, biweekly papier skip, coloc-only access middleware

### DIFF
--- a/src/chores.py
+++ b/src/chores.py
@@ -26,6 +26,138 @@ def _current_week_key() -> str:
     return f"{iso[0]}-W{iso[1]:02d}"
 
 
+def toggle_role(role: str, person: str) -> bool:
+    """Toggle a simple role's completion. Returns True if now done."""
+    table = _get_table()
+    week_key = _current_week_key()
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    table.update_item(
+        Key={"week_key": week_key},
+        UpdateExpression="SET completed = if_not_exists(completed, :empty_map)",
+        ExpressionAttributeValues={":empty_map": {}},
+    )
+
+    status = get_week_status(week_key)
+    if role in status and "by" in status[role]:
+        table.update_item(
+            Key={"week_key": week_key},
+            UpdateExpression="REMOVE completed.#role",
+            ExpressionAttributeNames={"#role": role},
+        )
+        logger.info("Toggled %s OFF for %s", role, week_key)
+        return False
+    else:
+        table.update_item(
+            Key={"week_key": week_key},
+            UpdateExpression="SET completed.#role = :val",
+            ExpressionAttributeNames={"#role": role},
+            ExpressionAttributeValues={":val": {"by": person, "at": now}},
+        )
+        logger.info("Toggled %s ON by %s for %s", role, person, week_key)
+        return True
+
+
+def toggle_subtask(role: str, subtask: str, person: str) -> bool:
+    """Toggle a sub-task's completion. Returns True if now done."""
+    table = _get_table()
+    week_key = _current_week_key()
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    table.update_item(
+        Key={"week_key": week_key},
+        UpdateExpression="SET completed = if_not_exists(completed, :empty_map)",
+        ExpressionAttributeValues={":empty_map": {}},
+    )
+    table.update_item(
+        Key={"week_key": week_key},
+        UpdateExpression="SET completed.#role = if_not_exists(completed.#role, :empty_subtasks)",
+        ExpressionAttributeNames={"#role": role},
+        ExpressionAttributeValues={":empty_subtasks": {"subtasks": {}}},
+    )
+
+    status = get_week_status(week_key)
+    role_data = status.get(role, {})
+    subtasks = role_data.get("subtasks", {})
+
+    if subtask in subtasks:
+        table.update_item(
+            Key={"week_key": week_key},
+            UpdateExpression="REMOVE completed.#role.subtasks.#subtask",
+            ExpressionAttributeNames={"#role": role, "#subtask": subtask},
+        )
+        logger.info("Toggled %s.%s OFF for %s", role, subtask, week_key)
+        return False
+    else:
+        table.update_item(
+            Key={"week_key": week_key},
+            UpdateExpression="SET completed.#role.subtasks.#subtask = :val",
+            ExpressionAttributeNames={"#role": role, "#subtask": subtask},
+            ExpressionAttributeValues={":val": {"by": person, "at": now}},
+        )
+        logger.info("Toggled %s.%s ON by %s for %s", role, subtask, person, week_key)
+        return True
+
+
+def is_role_complete(role: str, completed_map: dict) -> bool:
+    """Check if a role is fully completed, handling both old and new formats."""
+    from src.menage import get_subtasks_for_role
+
+    if role not in completed_map:
+        return False
+
+    role_data = completed_map[role]
+
+    # Old format: {by, at}
+    if "by" in role_data:
+        return True
+
+    # New format: {subtasks: {name: {by, at}, ...}}
+    if "subtasks" in role_data:
+        expected = get_subtasks_for_role(role)
+        if expected is None:
+            return False
+        completed_subtasks = role_data["subtasks"]
+        return all(s in completed_subtasks for s in expected)
+
+    return False
+
+
+def _pending_detail(role: str, completed: dict) -> str:
+    """Return detail string for sub-task roles with missing items."""
+    from src.menage import get_subtasks_for_role
+
+    if role not in completed:
+        return ""
+
+    role_data = completed[role]
+    if "subtasks" not in role_data:
+        return ""
+
+    expected = get_subtasks_for_role(role)
+    if expected is None:
+        return ""
+
+    completed_subtasks = role_data.get("subtasks", {})
+    missing = [s for s in expected if s not in completed_subtasks]
+    if missing:
+        return f" [manque : {', '.join(missing)}]"
+    return ""
+
+
+def _who_did_it(role_data: dict) -> str:
+    """Extract person name(s) from either format."""
+    if "by" in role_data:
+        return role_data["by"]
+    if "subtasks" in role_data:
+        names = set()
+        for sub_data in role_data["subtasks"].values():
+            if "by" in sub_data:
+                names.add(sub_data["by"])
+        return ", ".join(sorted(names)) if names else "?"
+    return "?"
+
+
 def mark_done(role: str, person: str) -> bool:
     """Mark a role as done for the current week.
 
@@ -80,10 +212,11 @@ def get_thursday_reminder(role_assignments: dict) -> str:
     pending = []
     done = []
     for role, person in role_assignments.items():
-        if role in completed:
+        if is_role_complete(role, completed):
             done.append(f"  {role} ({person})")
         else:
-            pending.append(f"  {role} ({person})")
+            detail = _pending_detail(role, completed)
+            pending.append(f"  {role} ({person}){detail}")
 
     if not pending:
         return "Rappel du jeudi : tout est fait cette semaine, bravo !"
@@ -107,10 +240,20 @@ def get_stats() -> str:
     counts: dict[str, int] = {}
     for item in items:
         completed = item.get("completed", {})
-        for role_data in completed.values():
-            person = role_data.get("by")
-            if person:
+        for role, role_data in completed.items():
+            # Old format: {by, at}
+            if "by" in role_data:
+                person = role_data["by"]
                 counts[person] = counts.get(person, 0) + 1
+            # New format: {subtasks: {name: {by, at}, ...}}
+            elif "subtasks" in role_data:
+                if is_role_complete(role, completed):
+                    names = set()
+                    for sub_data in role_data["subtasks"].values():
+                        if "by" in sub_data:
+                            names.add(sub_data["by"])
+                    for person in names:
+                        counts[person] = counts.get(person, 0) + 1
 
     if not counts:
         return "Pas encore de stats !"
@@ -133,9 +276,9 @@ def get_sunday_recap(role_assignments: dict) -> str:
     completed = get_week_status()
     lines = ["Récap de la semaine :"]
     for role, person in role_assignments.items():
-        if role in completed:
-            info = completed[role]
-            lines.append(f"  \u2705 {role} ({person}) — fait par {info['by']}")
+        if is_role_complete(role, completed):
+            who = _who_did_it(completed[role])
+            lines.append(f"  \u2705 {role} ({person}) — fait par {who}")
         else:
             lines.append(f"  \u274c {role} ({person}) — pas fait")
     return "\n".join(lines)

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -64,7 +64,8 @@ class Drahmbot:
         self.token = token or utils.get_token()
         self.chat_id = chat_id or utils.get_group_id()
         self.dev_chat_id = utils.get_dev_chat_id()
-        self.bot = AsyncTeleBot(self.token, parse_mode=None, use_class_middlewares=True)
+        self.bot = AsyncTeleBot(self.token, parse_mode=None)
+        self.bot.use_class_middlewares = True
         logger.info("Initializing Drahmbot with chat_id: %s", self.chat_id)
         self.bot.setup_middleware(ColocAccessMiddleware(TELEGRAM_USER_MAP))
         self.register_handlers()

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import telebot
@@ -32,19 +33,69 @@ class ColocAccessMiddleware(BaseMiddleware):
     def __init__(self, user_map):
         super().__init__()
         self.user_map = user_map
-        self.update_types = ['message']
+        self.update_types = ['message', 'callback_query']
 
     async def pre_process(self, message, data):
         from_user = message.from_user
         if from_user is None:
             return
-        if message.text and message.text.strip().startswith('/myid'):
+        if hasattr(message, 'text') and message.text and message.text.strip().startswith('/myid'):
             return
         if from_user.id not in self.user_map:
             return CancelUpdate()
 
     async def post_process(self, message, data, exception):
         pass
+
+
+def _build_done_keyboard(role, week_num):
+    """Build an InlineKeyboardMarkup for a role's done status."""
+    subtasks = menage.get_subtasks_for_role(role)
+    keyboard = telebot.types.InlineKeyboardMarkup()
+
+    completed = chores.get_week_status()
+    role_data = completed.get(role, {})
+
+    if subtasks is None:
+        is_done = "by" in role_data
+        icon = "\u2705" if is_done else "\u2b1c"
+        button = telebot.types.InlineKeyboardButton(
+            text=f"{icon} {role}",
+            callback_data=f"done:{week_num}:{role}",
+        )
+        keyboard.add(button)
+    else:
+        completed_subtasks = role_data.get("subtasks", {})
+        for subtask in subtasks:
+            is_done = subtask in completed_subtasks
+            icon = "\u2705" if is_done else "\u2b1c"
+            button = telebot.types.InlineKeyboardButton(
+                text=f"{icon} {subtask}",
+                callback_data=f"done:{week_num}:{role}:{subtask}",
+            )
+            keyboard.add(button)
+
+    return keyboard
+
+
+def _build_done_text(role, person):
+    """Build status text for a role's done message."""
+    subtasks = menage.get_subtasks_for_role(role)
+    completed = chores.get_week_status()
+    role_data = completed.get(role, {})
+
+    if subtasks is None:
+        is_done = "by" in role_data
+        if is_done:
+            return f"{person} \u2014 {role} : fait \u2705"
+        return f"{person} \u2014 {role} : clique pour marquer comme fait."
+    else:
+        completed_subtasks = role_data.get("subtasks", {})
+        done_count = sum(1 for s in subtasks if s in completed_subtasks)
+        total = len(subtasks)
+        if done_count == total:
+            return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites \u2705"
+        return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites."
 
 
 class Drahmbot:
@@ -160,12 +211,66 @@ class Drahmbot:
                 )
                 return
 
-            newly_done = chores.mark_done(role, person)
-            if newly_done:
-                answer = f"Bien joué {person} ! {role} marqué comme fait."
+            week_num = datetime.date.today().isocalendar()[1]
+            keyboard = _build_done_keyboard(role, week_num)
+            text = _build_done_text(role, person)
+            await self.bot.send_message(message.chat.id, text, reply_markup=keyboard)
+
+        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("done:"))
+        async def handle_done_callback(call):
+            parts = call.data.split(":")
+            if len(parts) < 3:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+
+            week_num = int(parts[1])
+            role = parts[2]
+            subtask = parts[3] if len(parts) > 3 else None
+
+            current_week = datetime.date.today().isocalendar()[1]
+            if week_num != current_week:
+                await self.bot.answer_callback_query(
+                    call.id, "Cette semaine est terminée.", show_alert=True,
+                )
+                return
+
+            user_id = call.from_user.id
+            person = TELEGRAM_USER_MAP.get(user_id)
+            if not person:
+                await self.bot.answer_callback_query(
+                    call.id, "Tu n'es pas reconnu.", show_alert=True,
+                )
+                return
+
+            assigned_role = menage.get_role_for_person(colocataires, person)
+            if assigned_role != role:
+                await self.bot.answer_callback_query(
+                    call.id, "Ce n'est pas ta tâche !", show_alert=True,
+                )
+                return
+
+            if subtask:
+                valid_subtasks = menage.get_subtasks_for_role(role)
+                if valid_subtasks is None or subtask not in valid_subtasks:
+                    await self.bot.answer_callback_query(
+                        call.id, "Sous-tâche inconnue.", show_alert=True,
+                    )
+                    return
+                now_done = chores.toggle_subtask(role, subtask, person)
+                toast = f"{subtask} fait !" if now_done else f"{subtask} annulé."
             else:
-                answer = f"{role} est déjà marqué comme fait cette semaine."
-            await self.bot.send_message(message.chat.id, answer)
+                now_done = chores.toggle_role(role, person)
+                toast = f"{role} fait !" if now_done else f"{role} annulé."
+
+            keyboard = _build_done_keyboard(role, week_num)
+            text = _build_done_text(role, person)
+            await self.bot.edit_message_text(
+                text,
+                call.message.chat.id,
+                call.message.message_id,
+                reply_markup=keyboard,
+            )
+            await self.bot.answer_callback_query(call.id, toast)
 
         @self.bot.message_handler(commands=['reminder'])
         async def send_reminder(message):

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -3,6 +3,7 @@ import logging
 import telebot
 
 from telebot.async_telebot import AsyncTeleBot
+from telebot.handler_backends import BaseMiddleware, CancelUpdate
 import src.utils as utils
 import src.menage as menage
 import src.social as social
@@ -24,7 +25,27 @@ TELEGRAM_USER_MAP = {
     5503636012: LEA,
     891406979: ALEXIS,
     981443207: MAEL,
+    1645783874: TIMON,
 }
+
+class ColocAccessMiddleware(BaseMiddleware):
+    def __init__(self, user_map):
+        super().__init__()
+        self.user_map = user_map
+        self.update_types = ['message']
+
+    async def pre_process(self, message, data):
+        from_user = message.from_user
+        if from_user is None:
+            return
+        if message.text and message.text.strip().startswith('/myid'):
+            return
+        if from_user.id not in self.user_map:
+            return CancelUpdate()
+
+    async def post_process(self, message, data, exception):
+        pass
+
 
 class Drahmbot:
     _instance = None  # Singleton instance
@@ -43,8 +64,9 @@ class Drahmbot:
         self.token = token or utils.get_token()
         self.chat_id = chat_id or utils.get_group_id()
         self.dev_chat_id = utils.get_dev_chat_id()
-        self.bot = AsyncTeleBot(self.token, parse_mode=None)
+        self.bot = AsyncTeleBot(self.token, parse_mode=None, use_class_middlewares=True)
         logger.info("Initializing Drahmbot with chat_id: %s", self.chat_id)
+        self.bot.setup_middleware(ColocAccessMiddleware(TELEGRAM_USER_MAP))
         self.register_handlers()
         self._initialized = True
         logger.info("Drahmbot initialization complete")
@@ -62,6 +84,9 @@ class Drahmbot:
         @self.bot.message_handler(commands=['papier'])
         async def send_papier(message):
             logger.info("Command /papier received from %s", message.chat.id)
+            if not utils.is_even_week():
+                logger.info("Odd week — skipping papier reminder")
+                return
             answer = menage.get_papier_reminder(colocataires=colocataires)
             await self.bot.send_message(message.chat.id, answer)
             logger.info("Sent papier answer: %s", answer)

--- a/src/menage.py
+++ b/src/menage.py
@@ -7,6 +7,25 @@ logger = logging.getLogger(__name__)
 
 ROLES = ["CUISINE", "SDBs", "SOLs", "DÉCHETS"]
 
+ROLE_SUBTASKS = {
+    "CUISINE": None,
+    "SDBs": None,
+    "SOLs": ["aspirateur", "panosse"],
+    "DÉCHETS": ["poubelle", "carton", "compost", "verre", "plastique"],
+}
+DECHETS_OPTIONAL_SUBTASK = "papier"
+
+
+def get_subtasks_for_role(role):
+    """Return the list of active sub-tasks for a role, or None for simple roles."""
+    subtasks = ROLE_SUBTASKS.get(role)
+    if subtasks is None:
+        return None
+    result = list(subtasks)
+    if role == "DÉCHETS" and is_even_week():
+        result.append(DECHETS_OPTIONAL_SUBTASK)
+    return result
+
 '''
 Role computation
 '''

--- a/tests/test_chores.py
+++ b/tests/test_chores.py
@@ -201,3 +201,249 @@ def test_get_stats_no_completed_field(mock_get_table):
 
     result = chores.get_stats()
     assert result == "Pas encore de stats !"
+
+
+# --- toggle_role tests ---
+
+
+@patch("src.chores.get_week_status", return_value={})
+@patch("src.chores._current_week_key", return_value="2026-W14")
+@patch("src.chores._get_table")
+def test_toggle_role_on(mock_get_table, mock_week, mock_status):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = chores.toggle_role("CUISINE", "Timon")
+    assert result is True
+    # 1 call to ensure map + 1 call to SET role
+    assert mock_table.update_item.call_count == 2
+
+
+@patch("src.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+})
+@patch("src.chores._current_week_key", return_value="2026-W14")
+@patch("src.chores._get_table")
+def test_toggle_role_off(mock_get_table, mock_week, mock_status):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = chores.toggle_role("CUISINE", "Timon")
+    assert result is False
+    # 1 call to ensure map + 1 call to REMOVE role
+    assert mock_table.update_item.call_count == 2
+    last_call = mock_table.update_item.call_args_list[1][1]
+    assert "REMOVE" in last_call["UpdateExpression"]
+
+
+# --- toggle_subtask tests ---
+
+
+@patch("src.chores.get_week_status", return_value={})
+@patch("src.chores._current_week_key", return_value="2026-W14")
+@patch("src.chores._get_table")
+def test_toggle_subtask_on(mock_get_table, mock_week, mock_status):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = chores.toggle_subtask("DÉCHETS", "poubelle", "Alexis")
+    assert result is True
+    # 1 ensure map + 1 ensure role subtasks + 1 SET subtask
+    assert mock_table.update_item.call_count == 3
+
+
+@patch("src.chores.get_week_status", return_value={
+    "DÉCHETS": {"subtasks": {"poubelle": {"by": "Alexis", "at": "..."}}},
+})
+@patch("src.chores._current_week_key", return_value="2026-W14")
+@patch("src.chores._get_table")
+def test_toggle_subtask_off(mock_get_table, mock_week, mock_status):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = chores.toggle_subtask("DÉCHETS", "poubelle", "Alexis")
+    assert result is False
+    # 1 ensure map + 1 ensure role subtasks + 1 REMOVE subtask
+    assert mock_table.update_item.call_count == 3
+    last_call = mock_table.update_item.call_args_list[2][1]
+    assert "REMOVE" in last_call["UpdateExpression"]
+
+
+# --- is_role_complete tests ---
+
+
+def test_is_role_complete_missing():
+    assert chores.is_role_complete("CUISINE", {}) is False
+
+
+def test_is_role_complete_old_format():
+    completed = {"CUISINE": {"by": "Timon", "at": "..."}}
+    assert chores.is_role_complete("CUISINE", completed) is True
+
+
+@patch("src.menage.is_even_week", return_value=False)
+def test_is_role_complete_subtasks_all_done(mock_even):
+    completed = {
+        "SOLs": {
+            "subtasks": {
+                "aspirateur": {"by": "Léa", "at": "..."},
+                "panosse": {"by": "Léa", "at": "..."},
+            }
+        }
+    }
+    assert chores.is_role_complete("SOLs", completed) is True
+
+
+@patch("src.menage.is_even_week", return_value=False)
+def test_is_role_complete_subtasks_partial(mock_even):
+    completed = {
+        "SOLs": {
+            "subtasks": {
+                "aspirateur": {"by": "Léa", "at": "..."},
+            }
+        }
+    }
+    assert chores.is_role_complete("SOLs", completed) is False
+
+
+@patch("src.menage.is_even_week", return_value=True)
+def test_is_role_complete_dechets_even_week_needs_papier(mock_even):
+    completed = {
+        "DÉCHETS": {
+            "subtasks": {
+                "poubelle": {"by": "Alexis", "at": "..."},
+                "carton": {"by": "Alexis", "at": "..."},
+                "compost": {"by": "Alexis", "at": "..."},
+                "verre": {"by": "Alexis", "at": "..."},
+                "plastique": {"by": "Alexis", "at": "..."},
+            }
+        }
+    }
+    # Missing papier on even week → not complete
+    assert chores.is_role_complete("DÉCHETS", completed) is False
+
+
+# --- _pending_detail tests ---
+
+
+@patch("src.menage.is_even_week", return_value=False)
+def test_pending_detail_with_missing(mock_even):
+    completed = {
+        "SOLs": {
+            "subtasks": {
+                "aspirateur": {"by": "Léa", "at": "..."},
+            }
+        }
+    }
+    result = chores._pending_detail("SOLs", completed)
+    assert "panosse" in result
+    assert "manque" in result
+
+
+def test_pending_detail_role_not_started():
+    result = chores._pending_detail("SOLs", {})
+    assert result == ""
+
+
+def test_pending_detail_old_format():
+    completed = {"CUISINE": {"by": "Timon", "at": "..."}}
+    result = chores._pending_detail("CUISINE", completed)
+    assert result == ""
+
+
+# --- _who_did_it tests ---
+
+
+def test_who_did_it_old_format():
+    assert chores._who_did_it({"by": "Timon", "at": "..."}) == "Timon"
+
+
+def test_who_did_it_subtask_format():
+    role_data = {
+        "subtasks": {
+            "aspirateur": {"by": "Léa", "at": "..."},
+            "panosse": {"by": "Léa", "at": "..."},
+        }
+    }
+    assert chores._who_did_it(role_data) == "Léa"
+
+
+def test_who_did_it_empty():
+    assert chores._who_did_it({}) == "?"
+
+
+# --- reminder/recap with subtask format ---
+
+
+@patch("src.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+    "SDBs": {"by": "Maël", "at": "..."},
+    "SOLs": {"subtasks": {
+        "aspirateur": {"by": "Léa", "at": "..."},
+        "panosse": {"by": "Léa", "at": "..."},
+    }},
+    "DÉCHETS": {"subtasks": {
+        "poubelle": {"by": "Alexis", "at": "..."},
+    }},
+})
+@patch("src.menage.is_even_week", return_value=False)
+def test_thursday_reminder_with_subtasks(mock_even, mock_status):
+    result = chores.get_thursday_reminder(SAMPLE_ASSIGNMENTS)
+    # DÉCHETS is not fully done (only poubelle of 5)
+    assert "DÉCHETS" in result
+    assert "manque" in result
+    # SOLs is fully done
+    assert "Déjà fait" in result
+
+
+@patch("src.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+    "SDBs": {"by": "Maël", "at": "..."},
+    "SOLs": {"subtasks": {
+        "aspirateur": {"by": "Léa", "at": "..."},
+        "panosse": {"by": "Léa", "at": "..."},
+    }},
+    "DÉCHETS": {"by": "Alexis", "at": "..."},
+})
+def test_sunday_recap_mixed_formats(mock_status):
+    result = chores.get_sunday_recap(SAMPLE_ASSIGNMENTS)
+    assert "Récap" in result
+    assert "fait par Timon" in result
+    assert "fait par Léa" in result
+    assert "fait par Alexis" in result
+    assert "pas fait" not in result
+
+
+# --- stats with subtask format ---
+
+
+@patch("src.menage.is_even_week", return_value=False)
+@patch("src.chores._get_table")
+def test_get_stats_with_subtask_format(mock_get_table, mock_even):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {
+                "week_key": "2026-W14",
+                "completed": {
+                    "CUISINE": {"by": "Timon", "at": "..."},
+                    "SOLs": {"subtasks": {
+                        "aspirateur": {"by": "Léa", "at": "..."},
+                        "panosse": {"by": "Léa", "at": "..."},
+                    }},
+                    "DÉCHETS": {"subtasks": {
+                        "poubelle": {"by": "Alexis", "at": "..."},
+                    }},
+                },
+            },
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    result = chores.get_stats()
+    # Timon: 1 (CUISINE old format)
+    assert "Timon : 1 tâches" in result
+    # Léa: 1 (SOLs fully complete)
+    assert "Léa : 1 tâches" in result
+    # Alexis: 0 (DÉCHETS not fully complete — only 1 of 5 subtasks)
+    assert "Alexis" not in result

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 from unittest.mock import AsyncMock, patch, MagicMock
-from src.drahmbot import Drahmbot, colocataires
+from src.drahmbot import Drahmbot, ColocAccessMiddleware, TELEGRAM_USER_MAP, colocataires
 
 @pytest.mark.asyncio
 async def test_singleton_behavior():
@@ -44,12 +44,13 @@ def _capture_handlers(bot):
 @pytest.mark.asyncio
 @patch("src.drahmbot.utils.get_token", return_value="12345:12345")
 @patch("src.drahmbot.utils.get_group_id", return_value=123)
+@patch("src.drahmbot.utils.is_even_week", return_value=True)
 @patch("src.drahmbot.menage.getRoles", return_value="Roles info")
 @patch("src.drahmbot.menage.get_papier_reminder", return_value="Papier reminder")
 @patch("src.drahmbot.menage.getCarteDeLessive", return_value="Lessive info")
 @patch("src.drahmbot.social.is_present_dinner", return_value="Who is here?")
 async def test_bot_handlers(
-    mock_who, mock_lessive, mock_papier, mock_roles, mock_group, mock_token
+    mock_who, mock_lessive, mock_papier, mock_roles, mock_even, mock_group, mock_token
 ):
     bot = Drahmbot()
 
@@ -268,3 +269,64 @@ async def test_stats_handler_other_chat_ignored(mock_group, mock_token, mock_sta
 
     await handlers["stats"](message)
     bot.bot.send_message.assert_not_called()
+
+
+# --- Biweekly papier tests ---
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.utils.is_even_week", return_value=False)
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_papier_skipped_on_odd_week(mock_group, mock_token, mock_even):
+    bot = Drahmbot()
+    bot.bot.send_message = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    message = MagicMock()
+    message.chat.id = 999
+
+    await handlers["papier"](message)
+    bot.bot.send_message.assert_not_called()
+
+
+# --- ColocAccessMiddleware tests ---
+
+@pytest.mark.asyncio
+async def test_middleware_allows_known_user():
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    message = MagicMock()
+    message.from_user.id = 891406979  # Alexis
+    message.text = "/roles"
+    result = await mw.pre_process(message, {})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_blocks_unknown_user():
+    from telebot.handler_backends import CancelUpdate
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    message = MagicMock()
+    message.from_user.id = 99999999  # Not in map
+    message.text = "/roles"
+    result = await mw.pre_process(message, {})
+    assert isinstance(result, CancelUpdate)
+
+
+@pytest.mark.asyncio
+async def test_middleware_allows_eventbridge():
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    message = MagicMock()
+    message.from_user = None
+    message.text = "/papier"
+    result = await mw.pre_process(message, {})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_allows_myid():
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    message = MagicMock()
+    message.from_user.id = 99999999  # Unknown user
+    message.text = "/myid"
+    result = await mw.pre_process(message, {})
+    assert result is None

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -1,7 +1,11 @@
+import datetime
 import pytest
 import asyncio
 from unittest.mock import AsyncMock, patch, MagicMock
-from src.drahmbot import Drahmbot, ColocAccessMiddleware, TELEGRAM_USER_MAP, colocataires
+from src.drahmbot import (
+    Drahmbot, ColocAccessMiddleware, TELEGRAM_USER_MAP, colocataires,
+    _build_done_keyboard, _build_done_text,
+)
 
 @pytest.mark.asyncio
 async def test_singleton_behavior():
@@ -22,11 +26,10 @@ async def test_process_update(mock_de_json):
 
 
 def _capture_handlers(bot):
-    """Re-register handlers and capture them by command name."""
+    """Re-register handlers and capture them by command name (and callback queries)."""
     handlers = {}
-    original_message_handler = bot.bot.message_handler
 
-    def capture_handler(*args, **kwargs):
+    def capture_message_handler(*args, **kwargs):
         def wrapper(func):
             if "commands" in kwargs:
                 for cmd in kwargs["commands"]:
@@ -36,7 +39,14 @@ def _capture_handlers(bot):
             return func
         return wrapper
 
-    bot.bot.message_handler = capture_handler
+    def capture_callback_handler(*args, **kwargs):
+        def wrapper(func):
+            handlers["_callback_query"] = func
+            return func
+        return wrapper
+
+    bot.bot.message_handler = capture_message_handler
+    bot.bot.callback_query_handler = capture_callback_handler
     bot.register_handlers()
     return handlers
 
@@ -133,11 +143,16 @@ async def test_done_handler_unknown_user(mock_group, mock_token):
 
 
 @pytest.mark.asyncio
-@patch("src.drahmbot.chores.mark_done", return_value=True)
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
 @patch("src.drahmbot.menage.get_role_for_person", return_value="CUISINE")
+@patch("src.drahmbot.datetime")
 @patch("src.drahmbot.utils.get_token", return_value="12345:12345")
 @patch("src.drahmbot.utils.get_group_id", return_value=123)
-async def test_done_handler_success(mock_group, mock_token, mock_role, mock_mark):
+async def test_done_handler_sends_keyboard(
+    mock_group, mock_token, mock_dt, mock_role, mock_subtasks, mock_status,
+):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
     import src.drahmbot as drahmbot_module
     original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
     drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"
@@ -153,22 +168,29 @@ async def test_done_handler_success(mock_group, mock_token, mock_role, mock_mark
 
         await handlers["done"](message)
         call_args = bot.bot.send_message.call_args
-        assert "Bien joué" in call_args[0][1]
         assert "CUISINE" in call_args[0][1]
+        assert "reply_markup" in call_args[1]
     finally:
         drahmbot_module.TELEGRAM_USER_MAP.clear()
         drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
 
 
 @pytest.mark.asyncio
-@patch("src.drahmbot.chores.mark_done", return_value=False)
-@patch("src.drahmbot.menage.get_role_for_person", return_value="CUISINE")
+@patch("src.drahmbot.chores.get_week_status", return_value={
+    "SOLs": {"subtasks": {"aspirateur": {"by": "Léa", "at": "..."}}},
+})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["aspirateur", "panosse"])
+@patch("src.drahmbot.menage.get_role_for_person", return_value="SOLs")
+@patch("src.drahmbot.datetime")
 @patch("src.drahmbot.utils.get_token", return_value="12345:12345")
 @patch("src.drahmbot.utils.get_group_id", return_value=123)
-async def test_done_handler_already_done(mock_group, mock_token, mock_role, mock_mark):
+async def test_done_handler_subtask_role(
+    mock_group, mock_token, mock_dt, mock_role, mock_subtasks, mock_status,
+):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
     import src.drahmbot as drahmbot_module
     original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
-    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Léa"
 
     try:
         bot = Drahmbot()
@@ -181,7 +203,10 @@ async def test_done_handler_already_done(mock_group, mock_token, mock_role, mock
 
         await handlers["done"](message)
         call_args = bot.bot.send_message.call_args
-        assert "déjà marqué" in call_args[0][1]
+        text = call_args[0][1]
+        assert "1/2" in text
+        keyboard = call_args[1]["reply_markup"]
+        assert len(keyboard.keyboard) == 2  # 2 subtask buttons
     finally:
         drahmbot_module.TELEGRAM_USER_MAP.clear()
         drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
@@ -330,3 +355,222 @@ async def test_middleware_allows_myid():
     message.text = "/myid"
     result = await mw.pre_process(message, {})
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_allows_known_user_callback():
+    """Callback queries from known users pass through middleware."""
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    callback = MagicMock(spec=[])  # no 'text' attribute
+    callback.from_user = MagicMock()
+    callback.from_user.id = 891406979  # Alexis
+    result = await mw.pre_process(callback, {})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_blocks_unknown_user_callback():
+    from telebot.handler_backends import CancelUpdate
+    mw = ColocAccessMiddleware(TELEGRAM_USER_MAP)
+    callback = MagicMock(spec=[])  # no 'text' attribute
+    callback.from_user = MagicMock()
+    callback.from_user.id = 99999999
+    result = await mw.pre_process(callback, {})
+    assert isinstance(result, CancelUpdate)
+
+
+# --- Keyboard builder tests ---
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
+def test_build_done_keyboard_simple_role(mock_subtasks, mock_status):
+    keyboard = _build_done_keyboard("CUISINE", 15)
+    assert len(keyboard.keyboard) == 1
+    btn = keyboard.keyboard[0][0]
+    assert "CUISINE" in btn.text
+    assert btn.callback_data == "done:15:CUISINE"
+    assert "\u2b1c" in btn.text  # not done
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
+def test_build_done_keyboard_simple_done(mock_subtasks, mock_status):
+    keyboard = _build_done_keyboard("CUISINE", 15)
+    btn = keyboard.keyboard[0][0]
+    assert "\u2705" in btn.text
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["aspirateur", "panosse"])
+def test_build_done_keyboard_subtask_role(mock_subtasks, mock_status):
+    keyboard = _build_done_keyboard("SOLs", 15)
+    assert len(keyboard.keyboard) == 2
+    assert "aspirateur" in keyboard.keyboard[0][0].text
+    assert "panosse" in keyboard.keyboard[1][0].text
+    assert keyboard.keyboard[0][0].callback_data == "done:15:SOLs:aspirateur"
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
+def test_build_done_text_simple_not_done(mock_subtasks, mock_status):
+    text = _build_done_text("CUISINE", "Timon")
+    assert "CUISINE" in text
+    assert "Timon" in text
+    assert "clique" in text
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
+def test_build_done_text_simple_done(mock_subtasks, mock_status):
+    text = _build_done_text("CUISINE", "Timon")
+    assert "fait" in text
+    assert "\u2705" in text
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={
+    "SOLs": {"subtasks": {"aspirateur": {"by": "Léa", "at": "..."}}},
+})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["aspirateur", "panosse"])
+def test_build_done_text_subtask_partial(mock_subtasks, mock_status):
+    text = _build_done_text("SOLs", "Léa")
+    assert "1/2" in text
+
+
+# --- Callback handler tests ---
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.get_week_status", return_value={
+    "CUISINE": {"by": "Timon", "at": "..."},
+})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=None)
+@patch("src.drahmbot.chores.toggle_role", return_value=False)
+@patch("src.drahmbot.menage.get_role_for_person", return_value="CUISINE")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_callback_toggle_role(
+    mock_group, mock_token, mock_dt, mock_role, mock_toggle,
+    mock_subtasks, mock_status,
+):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "done:15:CUISINE"
+        call.from_user.id = 42
+        call.id = "cb1"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_toggle.assert_called_once_with("CUISINE", "Timon")
+        bot.bot.edit_message_text.assert_called_once()
+        bot.bot.answer_callback_query.assert_called_once()
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "annulé" in toast
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["aspirateur", "panosse"])
+@patch("src.drahmbot.chores.toggle_subtask", return_value=True)
+@patch("src.drahmbot.menage.get_role_for_person", return_value="SOLs")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_callback_toggle_subtask(
+    mock_group, mock_token, mock_dt, mock_role, mock_toggle,
+    mock_subtasks, mock_status,
+):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Léa"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "done:15:SOLs:aspirateur"
+        call.from_user.id = 42
+        call.id = "cb2"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_toggle.assert_called_once_with("SOLs", "aspirateur", "Léa")
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "aspirateur fait" in toast
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_callback_stale_week(mock_group, mock_token, mock_dt):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 16, 1)
+
+    bot = Drahmbot()
+    bot.bot.answer_callback_query = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    call = MagicMock()
+    call.data = "done:15:CUISINE"  # week 15, but current is 16
+    call.from_user.id = 891406979
+    call.id = "cb3"
+
+    await handlers["_callback_query"](call)
+    toast = bot.bot.answer_callback_query.call_args
+    assert "terminée" in toast[0][1]
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.menage.get_role_for_person", return_value="SDBs")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_callback_wrong_user(mock_group, mock_token, mock_dt, mock_role):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Maël"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "done:15:CUISINE"  # Maël is assigned SDBs, not CUISINE
+        call.from_user.id = 42
+        call.id = "cb4"
+
+        await handlers["_callback_query"](call)
+        toast = bot.bot.answer_callback_query.call_args
+        assert "pas ta tâche" in toast[0][1]
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)

--- a/tests/test_menage.py
+++ b/tests/test_menage.py
@@ -127,3 +127,66 @@ def test_changeRoles_odd_week(mock_getRoles, mock_even):
     assert "Coucou, changement" in result
     assert "roles text" in result
     mock_getRoles.assert_called_once_with(colocataires)
+
+
+# --- Sub-task definitions tests ---
+
+
+def test_role_subtasks_keys_match_roles():
+    from src.menage import ROLE_SUBTASKS, ROLES
+    assert set(ROLE_SUBTASKS.keys()) == set(ROLES)
+
+
+def test_simple_roles_have_no_subtasks():
+    from src.menage import ROLE_SUBTASKS
+    assert ROLE_SUBTASKS["CUISINE"] is None
+    assert ROLE_SUBTASKS["SDBs"] is None
+
+
+def test_sols_subtasks():
+    from src.menage import ROLE_SUBTASKS
+    assert ROLE_SUBTASKS["SOLs"] == ["aspirateur", "panosse"]
+
+
+def test_dechets_base_subtasks_exclude_papier():
+    from src.menage import ROLE_SUBTASKS
+    assert "papier" not in ROLE_SUBTASKS["DÉCHETS"]
+    assert "poubelle" in ROLE_SUBTASKS["DÉCHETS"]
+
+
+@patch("src.menage.is_even_week", return_value=True)
+def test_get_subtasks_dechets_even_week_includes_papier(mock_even):
+    from src.menage import get_subtasks_for_role
+    result = get_subtasks_for_role("DÉCHETS")
+    assert "papier" in result
+    assert "poubelle" in result
+    assert len(result) == 6
+
+
+@patch("src.menage.is_even_week", return_value=False)
+def test_get_subtasks_dechets_odd_week_excludes_papier(mock_even):
+    from src.menage import get_subtasks_for_role
+    result = get_subtasks_for_role("DÉCHETS")
+    assert "papier" not in result
+    assert "poubelle" in result
+    assert len(result) == 5
+
+
+def test_get_subtasks_simple_role_returns_none():
+    from src.menage import get_subtasks_for_role
+    assert get_subtasks_for_role("CUISINE") is None
+    assert get_subtasks_for_role("SDBs") is None
+
+
+def test_get_subtasks_sols():
+    from src.menage import get_subtasks_for_role
+    result = get_subtasks_for_role("SOLs")
+    assert result == ["aspirateur", "panosse"]
+
+
+def test_get_subtasks_returns_copy():
+    """Modifying the returned list should not affect the original."""
+    from src.menage import get_subtasks_for_role, ROLE_SUBTASKS
+    result = get_subtasks_for_role("SOLs")
+    result.append("extra")
+    assert "extra" not in ROLE_SUBTASKS["SOLs"]


### PR DESCRIPTION
- Add Timon's Telegram ID (1645783874) to TELEGRAM_USER_MAP
- Skip /papier on odd ISO weeks (collection is biweekly, even weeks only)
- Add ColocAccessMiddleware to block non-coloc users, with /myid exemption