### PR TITLE
feat: varied natural bot messages, chaos week, SDBs poubelle subtask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bugs/
 nohup.out
 bot.log
 .venv
+.config
 
 # Terraform
 infra/.terraform/

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_event_target" "reminder" {
   input = jsonencode({
     body = jsonencode({
       message = {
-        chat = { id = tonumber(local.dev_chat_id) }
+        chat = { id = tonumber(local.prod_chat_id) }
         text = local.schedules.reminder.command
         entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.reminder.command) }]
       }
@@ -154,7 +154,7 @@ resource "aws_cloudwatch_event_target" "recap" {
   input = jsonencode({
     body = jsonencode({
       message = {
-        chat = { id = tonumber(local.dev_chat_id) }
+        chat = { id = tonumber(local.prod_chat_id) }
         text = local.schedules.recap.command
         entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.recap.command) }]
       }

--- a/src/chores.py
+++ b/src/chores.py
@@ -159,39 +159,6 @@ def _who_did_it(role_data: dict) -> str:
     return "?"
 
 
-def mark_done(role: str, person: str) -> bool:
-    """Mark a role as done for the current week.
-
-    Returns True if newly marked, False if already done.
-    """
-    table = _get_table()
-    week_key = _current_week_key()
-    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
-
-    # Ensure the item and completed map exist (no-op if already present)
-    table.update_item(
-        Key={"week_key": week_key},
-        UpdateExpression="SET completed = if_not_exists(completed, :empty_map)",
-        ExpressionAttributeValues={":empty_map": {}},
-    )
-
-    try:
-        table.update_item(
-            Key={"week_key": week_key},
-            UpdateExpression="SET completed.#role = :val",
-            ConditionExpression="attribute_not_exists(completed.#role)",
-            ExpressionAttributeNames={"#role": role},
-            ExpressionAttributeValues={
-                ":val": {"by": person, "at": now}
-            },
-        )
-        logger.info("Marked %s as done by %s for %s", role, person, week_key)
-        return True
-    except table.meta.client.exceptions.ConditionalCheckFailedException:
-        logger.info("Role %s already marked done for %s", role, week_key)
-        return False
-
-
 def get_week_status(week_key: str = None) -> dict:
     """Get the completion status for a week. Returns the completed map (may be empty)."""
     table = _get_table()

--- a/src/chores.py
+++ b/src/chores.py
@@ -3,6 +3,8 @@ import logging
 import datetime
 import boto3
 
+from src import phrases
+
 logger = logging.getLogger(__name__)
 
 _table = None
@@ -218,13 +220,13 @@ def get_thursday_reminder(role_assignments: dict) -> str:
             pending.append(f"  {role} ({person}){detail}")
 
     if not pending:
-        return "Rappel du jeudi : tout est fait cette semaine, bravo !"
+        return phrases.pick(phrases.THURSDAY_ALL_DONE)
 
-    lines = ["Rappel du jeudi — tâches pas encore faites :"]
+    lines = [phrases.pick(phrases.THURSDAY_REMINDER_HEADER)]
     for item in pending:
         lines.append(f"  \u274c{item}")
     if done:
-        lines.append("Déjà fait :")
+        lines.append(phrases.pick(phrases.THURSDAY_DONE_SECTION))
         for item in done:
             lines.append(f"  \u2705{item}")
     return "\n".join(lines)
@@ -255,11 +257,11 @@ def get_stats() -> str:
                         counts[person] = counts.get(person, 0) + 1
 
     if not counts:
-        return "Pas encore de stats !"
+        return phrases.pick(phrases.STATS_EMPTY)
 
     medals = ["🥇", "🥈", "🥉"]
     sorted_people = sorted(counts.items(), key=lambda x: x[1], reverse=True)
-    lines = ["Stats :"]
+    lines = [phrases.pick(phrases.STATS_HEADER)]
     for i, (person, count) in enumerate(sorted_people):
         prefix = f"  {medals[i]} " if i < len(medals) else "  "
         lines.append(f"{prefix}{person} : {count} tâches")
@@ -273,7 +275,7 @@ def get_sunday_recap(role_assignments: dict) -> str:
         role_assignments: dict of {role: person} for the current week.
     """
     completed = get_week_status()
-    lines = ["Récap de la semaine :"]
+    lines = [phrases.pick(phrases.SUNDAY_RECAP_HEADER)]
     for role, person in role_assignments.items():
         if is_role_complete(role, completed):
             who = _who_did_it(completed[role])

--- a/src/menage.py
+++ b/src/menage.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from src.utils import is_even_week
+from src import phrases
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ def getRoles(colocataires: list):
     assignments = get_role_assignments(colocataires)
     logger.info("Role assignments: %s", assignments)
 
-    answer = """
+    body = """
         ROLES DU MENAGES ATTRIBUÉS ALEATOIREMENT PAR LE DRAHMBOT    :
         - \U0001F373 CUISINE    : {}
         - \U0001F6BF SDBs       : {}
@@ -70,6 +71,7 @@ def getRoles(colocataires: list):
         assignments["DÉCHETS"],
     )
 
+    answer = phrases.pick(phrases.MONDAY_NEW_ROLES) + "\n" + body
     logger.info("Assigned roles:\n%s", answer.strip())
     return answer
 
@@ -116,17 +118,3 @@ et lâcher 100 balles
     return answer
 
 
-'''
-For schedulers
-'''
-
-def changeRoles(colocataires: list):
-    answer = getRoles(colocataires)
-
-    if is_even_week():
-        answer = "Encore une semaine avec les mêmes rôles ehehe\n" + answer
-    else:
-        answer = "Coucou, changement de rôles pour le ménage ehehe\n" + answer
-
-    logger.info("ChangeRoles message:\n%s", answer.strip())
-    return answer

--- a/src/menage.py
+++ b/src/menage.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import random
 from src.utils import is_even_week
 from src import phrases
 
@@ -7,6 +8,9 @@ from src import phrases
 logger = logging.getLogger(__name__)
 
 ROLES = ["CUISINE", "SDBs", "SOLs", "DÉCHETS"]
+
+# Chance that roles don't rotate this week — pure chaos/joke
+CHAOS_KEEP_ROLES_PROBABILITY = 0.05
 
 ROLE_SUBTASKS = {
     "CUISINE": ["frigo", "plan de travail", "rangement"],
@@ -31,9 +35,23 @@ def get_subtasks_for_role(role):
 Role computation
 '''
 
+def _should_keep_same_roles() -> bool:
+    """Deterministic per ISO week — True ~5% of the time as a playful prank."""
+    iso = datetime.datetime.now().isocalendar()
+    rng = random.Random(f"drahmbot-roles-{iso[0]}-{iso[1]}")
+    return rng.random() < CHAOS_KEEP_ROLES_PROBABILITY
+
+
 def get_role_assignments(colocataires: list) -> dict:
-    """Return a dict mapping role name to the assigned person for this week."""
+    """Return a dict mapping role name to the assigned person for this week.
+
+    Normally rotates by +1 each week; on a chaos week (~5% chance, deterministic
+    per ISO week) the shift stays at last week's value so everyone keeps their
+    role.
+    """
     current_week_nb = datetime.datetime.now().isocalendar()[1] + 1
+    if _should_keep_same_roles():
+        current_week_nb -= 1
     logger.info("Calculated role index shift: %d", current_week_nb)
     return {
         role: colocataires[(current_week_nb + i) % len(colocataires)]
@@ -71,7 +89,12 @@ def getRoles(colocataires: list):
         assignments["DÉCHETS"],
     )
 
-    answer = phrases.pick(phrases.MONDAY_NEW_ROLES) + "\n" + body
+    if _should_keep_same_roles():
+        prefix = phrases.pick(phrases.MONDAY_SAME_ROLES)
+    else:
+        prefix = phrases.pick(phrases.MONDAY_NEW_ROLES)
+
+    answer = prefix + "\n" + body
     logger.info("Assigned roles:\n%s", answer.strip())
     return answer
 

--- a/src/menage.py
+++ b/src/menage.py
@@ -117,20 +117,6 @@ def get_carton_reminder(colocataires: list) -> str:
     return answer
 
 
-def getCartonOrPapier(colocataires: list) -> str:
-    """Show the new papier/carton schedule and responsible person."""
-    assignments = get_role_assignments(colocataires)
-    name = assignments["DÉCHETS"]
-    answer = (
-        "Nouveau calendrier :\n"
-        "- Papier : tous les lundis soir\n"
-        "- Carton : tous les mercredis soir\n"
-        f"Cette semaine, c'est {name} (DÉCHETS) qui s'en occupe !"
-    )
-    logger.info("Carton/Papier info: %s", answer)
-    return answer
-
-
 def getCarteDeLessive():
     answer = """Pour commander une carte ou un badge, veuillez consulter le site internet
 https://www.lavorent.ch/fr/product/hyperion-100/

--- a/src/menage.py
+++ b/src/menage.py
@@ -9,7 +9,7 @@ ROLES = ["CUISINE", "SDBs", "SOLs", "DÉCHETS"]
 
 ROLE_SUBTASKS = {
     "CUISINE": ["frigo", "plan de travail", "rangement"],
-    "SDBs": ["petit WC", "grand WC", "lavabo", "baignoire"],
+    "SDBs": ["petit WC", "grand WC", "lavabo", "baignoire", "Vider les petites poubelles"],
     "SOLs": ["aspirateur", "panosse"],
     "DÉCHETS": ["poubelle", "carton", "compost", "verre", "plastique"],
 }

--- a/src/phrases.py
+++ b/src/phrases.py
@@ -1,0 +1,122 @@
+import random
+
+
+MONDAY_SAME_ROLES = [
+    "Encore une semaine avec les mêmes rôles ehehe",
+    "Rebelote, on garde la même équipe cette semaine",
+    "Pas de changement, mêmes rôles que la semaine dernière",
+    "On recycle les rôles pour encore une semaine ehehe",
+    "Même casting que la semaine passée, bon courage",
+    "Rôles inchangés, on continue sur la lancée",
+    "Deuxième service avec les mêmes rôles, bon app",
+    "Les rôles ont décidé de rester, on fait avec ehehe",
+    "Copier-coller des rôles de la semaine dernière",
+    "Même équipe, même combat, même poussière",
+    "La roue du ménage a oublié de tourner cette semaine",
+    "Bis repetita placent : rôles identiques ehehe",
+    "Les rôles font grève du tournage, même dispo que la semaine passée",
+    "Toujours les mêmes au charbon cette semaine, courage",
+]
+
+MONDAY_NEW_ROLES = [
+    "Coucou, changement de rôles pour le ménage ehehe",
+    "Pouet, on redistribue les tâches cette semaine",
+    "Nouveaux rôles de ménage, let's go",
+    "Nouvelle semaine, nouveaux rôles ehehe",
+    "Changement d'équipe pour le ménage, allez zou",
+    "Hop, on tourne les rôles ehehe",
+    "Pouet pouet, la roue du ménage a tourné",
+    "Redistribution des cartes, voilà les nouveaux rôles",
+    "La rotation a frappé, nouveaux rôles pour tout le monde",
+    "Reshuffle hebdomadaire, voici les nouveaux rôles ehehe",
+    "Changement de crémerie, nouveaux rôles cette semaine",
+    "Rebrassage complet, voilà qui fait quoi",
+    "Nouvelle donne pour le ménage, que les jeux commencent",
+    "La roulette du ménage a parlé ehehe",
+    "Coucou l'ekip, on change d'affectation cette semaine",
+]
+
+THURSDAY_ALL_DONE = [
+    "Rappel du jeudi : tout est fait cette semaine, bravo !",
+    "Jeudi check : tout est nickel, bravo l'ekip",
+    "Rien à rappeler aujourd'hui, la coloc a tout cartonné",
+    "Aucun rappel ce jeudi, tout est déjà fait. Bravo !",
+    "Jeudi : rien à signaler, tout est fait. Propre !",
+    "Jeudi tranquille : tout est bouclé, bravo la coloc",
+    "Jeudi sans stress, tout est fait, chapeau bas",
+    "La coloc a tout géré avant jeudi, respect ehehe",
+    "Rien à voir ce jeudi, circulez, c'est déjà propre",
+    "Jeudi zéro rappel : vous êtes des machines",
+    "Tout est fait, le bot est au chômage technique ehehe",
+    "Jeudi : le ménage a déjà été ménagé. Bravo",
+    "Aucune tâche en retard, c'est beau à voir",
+    "Coloc modèle, tout est fait avant le rappel. Pouet !",
+    "Jeudi propre sur lui : rien à signaler, bravo",
+]
+
+THURSDAY_REMINDER_HEADER = [
+    "Rappel du jeudi — tâches pas encore faites :",
+    "Pouet, petit rappel du jeudi, il reste :",
+    "Jeudi check — il manque encore ça :",
+    "Coucou, petit retard sur ces tâches :",
+    "Ehehe, le jeudi est là, et ça non plus n'est pas fait :",
+    "Rappel amical : ça traîne un peu du côté de :",
+    "Le bot passe en mode nag, il reste :",
+    "Jeudi, jour du rappel — pas encore fait :",
+    "Alerte poussière niveau jaune, il reste :",
+    "Toc toc, c'est le jeudi — à faire encore :",
+    "Petit coup de pouce du jeudi, il reste :",
+    "Hey l'ekip, y a encore du boulot :",
+    "Rappel de mi-semaine, pas encore coché :",
+    "Le bot vous rappelle gentiment qu'il reste :",
+]
+
+THURSDAY_DONE_SECTION = [
+    "Déjà fait :",
+    "Déjà bouclé (bravo) :",
+    "Au tableau d'honneur :",
+    "Déjà plié :",
+    "Dans la boîte :",
+    "Déjà OK :",
+    "Tip top, déjà fait :",
+    "Nickel, c'est fait :",
+    "Déjà coché :",
+    "Check, c'est fait :",
+]
+
+SUNDAY_RECAP_HEADER = [
+    "Récap de la semaine :",
+    "Bilan du dimanche soir :",
+    "Debrief de la semaine :",
+    "Petit récap dominical :",
+    "Récap hebdo, let's go :",
+    "Dimanche soir, heure du bilan :",
+    "Et voilà le debrief de la semaine :",
+    "Rétrospective ménage de la semaine :",
+    "Pouet, c'est l'heure du récap :",
+    "Dimanche récap, accrochez-vous :",
+    "Bilan avant de repartir pour une semaine :",
+    "Récap du week-end, qui a assuré :",
+]
+
+STATS_HEADER = [
+    "Stats :",
+    "Tableau d'honneur :",
+    "Leaderboard ménage :",
+    "Podium de la coloc :",
+    "Classement des pros du ménage :",
+    "Stats, pour les curieux :",
+]
+
+STATS_EMPTY = [
+    "Pas encore de stats !",
+    "Rien à compter pour l'instant, revenez plus tard",
+    "Les stats sont désespérément vides",
+    "Aucune stat à se mettre sous la dent",
+    "C'est le désert niveau stats, bougez-vous ehehe",
+]
+
+
+def pick(phrases):
+    """Return a random phrase from the given list."""
+    return random.choice(phrases)

--- a/src/social.py
+++ b/src/social.py
@@ -11,6 +11,3 @@ def is_present_dinner():
     logger.info("Generated dinner question: %s", question)
     return question
 
-# belle l'API de zuricho
-# https://github.com/opendatazurich/opendatazurich.github.io/tree/master
-

--- a/tests/test_chores.py
+++ b/tests/test_chores.py
@@ -22,39 +22,6 @@ def reset_table_cache():
 
 @patch("src.chores._current_week_key", return_value="2026-W14")
 @patch("src.chores._get_table")
-def test_mark_done_new(mock_get_table, mock_week):
-    mock_table = MagicMock()
-    mock_get_table.return_value = mock_table
-
-    result = chores.mark_done("CUISINE", "Timon")
-    assert result is True
-    # Two calls: first ensures map exists, second sets the role
-    assert mock_table.update_item.call_count == 2
-    call_kwargs = mock_table.update_item.call_args_list[1][1]
-    assert call_kwargs["Key"] == {"week_key": "2026-W14"}
-    assert call_kwargs["ExpressionAttributeNames"] == {"#role": "CUISINE"}
-
-
-@patch("src.chores._current_week_key", return_value="2026-W14")
-@patch("src.chores._get_table")
-def test_mark_done_already_done(mock_get_table, mock_week):
-    mock_table = MagicMock()
-    mock_client = MagicMock()
-    mock_table.meta.client = mock_client
-
-    # Simulate ConditionalCheckFailedException on the second call only
-    exc_class = type("ConditionalCheckFailedException", (Exception,), {})
-    mock_client.exceptions.ConditionalCheckFailedException = exc_class
-    # First call (ensure map) succeeds, second call (set role) fails
-    mock_table.update_item.side_effect = [None, exc_class("already done")]
-    mock_get_table.return_value = mock_table
-
-    result = chores.mark_done("CUISINE", "Timon")
-    assert result is False
-
-
-@patch("src.chores._current_week_key", return_value="2026-W14")
-@patch("src.chores._get_table")
 def test_get_week_status_empty(mock_get_table, mock_week):
     mock_table = MagicMock()
     mock_table.get_item.return_value = {}

--- a/tests/test_chores.py
+++ b/tests/test_chores.py
@@ -83,8 +83,9 @@ def test_get_week_status_with_data(mock_get_table, mock_week):
 
 @patch("src.chores.get_week_status", return_value={})
 def test_get_thursday_reminder_all_pending(mock_status):
+    from src.phrases import THURSDAY_REMINDER_HEADER
     result = chores.get_thursday_reminder(SAMPLE_ASSIGNMENTS)
-    assert "Rappel du jeudi" in result
+    assert any(h in result for h in THURSDAY_REMINDER_HEADER)
     assert "CUISINE" in result
     assert "SDBs" in result
 
@@ -96,26 +97,29 @@ def test_get_thursday_reminder_all_pending(mock_status):
     "DÉCHETS": {"by": "Alexis", "at": "..."},
 })
 def test_get_thursday_reminder_all_done(mock_status):
+    from src.phrases import THURSDAY_ALL_DONE
     result = chores.get_thursday_reminder(SAMPLE_ASSIGNMENTS)
-    assert "bravo" in result.lower()
+    assert result in THURSDAY_ALL_DONE
 
 
 @patch("src.chores.get_week_status", return_value={
     "CUISINE": {"by": "Timon", "at": "..."},
 })
 def test_get_thursday_reminder_partial(mock_status):
+    from src.phrases import THURSDAY_REMINDER_HEADER
     result = chores.get_thursday_reminder(SAMPLE_ASSIGNMENTS)
     assert "CUISINE" in result
     assert "SDBs" in result
-    assert "Rappel du jeudi" in result
+    assert any(h in result for h in THURSDAY_REMINDER_HEADER)
 
 
 @patch("src.chores.get_week_status", return_value={
     "CUISINE": {"by": "Timon", "at": "..."},
 })
 def test_get_sunday_recap(mock_status):
+    from src.phrases import SUNDAY_RECAP_HEADER
     result = chores.get_sunday_recap(SAMPLE_ASSIGNMENTS)
-    assert "Récap" in result
+    assert any(h in result for h in SUNDAY_RECAP_HEADER)
     assert "CUISINE" in result
     assert "fait par Timon" in result
     assert "pas fait" in result  # other roles not done
@@ -128,8 +132,9 @@ def test_get_sunday_recap(mock_status):
     "DÉCHETS": {"by": "Alexis", "at": "..."},
 })
 def test_get_sunday_recap_all_done(mock_status):
+    from src.phrases import SUNDAY_RECAP_HEADER
     result = chores.get_sunday_recap(SAMPLE_ASSIGNMENTS)
-    assert "Récap" in result
+    assert any(h in result for h in SUNDAY_RECAP_HEADER)
     assert "pas fait" not in result
 
 
@@ -139,8 +144,9 @@ def test_get_stats_empty(mock_get_table):
     mock_table.scan.return_value = {"Items": []}
     mock_get_table.return_value = mock_table
 
+    from src.phrases import STATS_EMPTY
     result = chores.get_stats()
-    assert result == "Pas encore de stats !"
+    assert result in STATS_EMPTY
 
 
 @patch("src.chores._get_table")
@@ -173,8 +179,9 @@ def test_get_stats_multiple_weeks(mock_get_table):
     }
     mock_get_table.return_value = mock_table
 
+    from src.phrases import STATS_HEADER
     result = chores.get_stats()
-    assert "Stats :" in result
+    assert any(h in result for h in STATS_HEADER)
     # Timon: 3 (W10 CUISINE, W11 CUISINE, W11 DÉCHETS)
     assert "Timon : 3 tâches" in result
     # Maël: 2 (W10 SDBs, W12 CUISINE)
@@ -199,8 +206,9 @@ def test_get_stats_no_completed_field(mock_get_table):
     }
     mock_get_table.return_value = mock_table
 
+    from src.phrases import STATS_EMPTY
     result = chores.get_stats()
-    assert result == "Pas encore de stats !"
+    assert result in STATS_EMPTY
 
 
 # --- toggle_role tests ---
@@ -390,12 +398,13 @@ def test_who_did_it_empty():
 })
 @patch("src.menage.is_even_week", return_value=False)
 def test_thursday_reminder_with_subtasks(mock_even, mock_status):
+    from src.phrases import THURSDAY_DONE_SECTION
     result = chores.get_thursday_reminder(SAMPLE_ASSIGNMENTS)
     # DÉCHETS is not fully done (only poubelle of 5)
     assert "DÉCHETS" in result
     assert "manque" in result
     # SOLs is fully done
-    assert "Déjà fait" in result
+    assert any(s in result for s in THURSDAY_DONE_SECTION)
 
 
 @patch("src.chores.get_week_status", return_value={
@@ -408,8 +417,9 @@ def test_thursday_reminder_with_subtasks(mock_even, mock_status):
     "DÉCHETS": {"by": "Alexis", "at": "..."},
 })
 def test_sunday_recap_mixed_formats(mock_status):
+    from src.phrases import SUNDAY_RECAP_HEADER
     result = chores.get_sunday_recap(SAMPLE_ASSIGNMENTS)
-    assert "Récap" in result
+    assert any(h in result for h in SUNDAY_RECAP_HEADER)
     assert "fait par Timon" in result
     assert "fait par Léa" in result
     assert "fait par Alexis" in result

--- a/tests/test_menage.py
+++ b/tests/test_menage.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 from src import menage
 
 
+@patch("src.menage._should_keep_same_roles", return_value=False)
 @patch("src.menage.datetime")
-def test_get_role_assignments(mock_datetime):
+def test_get_role_assignments(mock_datetime, mock_chaos):
     colocataires = ["Alice", "Bob", "Charlie", "Diana"]
     # Week 41 → shift = 42
     mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
@@ -15,8 +16,9 @@ def test_get_role_assignments(mock_datetime):
     assert set(assignments.values()) == set(colocataires)
 
 
+@patch("src.menage._should_keep_same_roles", return_value=False)
 @patch("src.menage.datetime")
-def test_get_role_assignments_rotates(mock_datetime):
+def test_get_role_assignments_rotates(mock_datetime, mock_chaos):
     colocataires = ["Alice", "Bob", "Charlie", "Diana"]
     # Week 41 → shift = 42
     mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
@@ -30,8 +32,9 @@ def test_get_role_assignments_rotates(mock_datetime):
     assert a1["CUISINE"] != a2["CUISINE"]
 
 
+@patch("src.menage._should_keep_same_roles", return_value=False)
 @patch("src.menage.datetime")
-def test_get_role_for_person(mock_datetime):
+def test_get_role_for_person(mock_datetime, mock_chaos):
     colocataires = ["Alice", "Bob", "Charlie", "Diana"]
     mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
     assignments = menage.get_role_assignments(colocataires)
@@ -44,18 +47,54 @@ def test_get_role_for_person(mock_datetime):
 
 def test_getRoles_has_dechets():
     """DÉCHETS line is present."""
-    with patch("src.menage.datetime") as mock_dt:
+    with patch("src.menage._should_keep_same_roles", return_value=False), \
+         patch("src.menage.datetime") as mock_dt:
         mock_dt.datetime.now.return_value = datetime.datetime(2023, 10, 9)
         result = menage.getRoles(["A", "B", "C", "D"])
         assert "DÉCHET" in result
 
 
+@patch("src.menage._should_keep_same_roles", return_value=False)
 @patch("src.menage.datetime")
-def test_getRoles_includes_new_roles_phrase(mock_datetime):
+def test_getRoles_normal_week_uses_new_roles_phrase(mock_datetime, mock_chaos):
     from src.phrases import MONDAY_NEW_ROLES
     mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
     result = menage.getRoles(["A", "B", "C", "D"])
     assert any(p in result for p in MONDAY_NEW_ROLES)
+
+
+@patch("src.menage._should_keep_same_roles", return_value=True)
+@patch("src.menage.datetime")
+def test_getRoles_chaos_week_uses_same_roles_phrase(mock_datetime, mock_chaos):
+    from src.phrases import MONDAY_SAME_ROLES
+    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
+    result = menage.getRoles(["A", "B", "C", "D"])
+    assert any(p in result for p in MONDAY_SAME_ROLES)
+
+
+@patch("src.menage._should_keep_same_roles", return_value=True)
+@patch("src.menage.datetime")
+def test_get_role_assignments_chaos_matches_previous_week(mock_datetime, mock_chaos):
+    """On a chaos week the shift is -1, giving the same assignment as a normal previous week."""
+    colocataires = ["Alice", "Bob", "Charlie", "Diana"]
+    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 16)  # Week 42
+    chaos = menage.get_role_assignments(colocataires)
+
+    # Normal week 41 assignments
+    mock_chaos.return_value = False
+    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)  # Week 41
+    normal_previous = menage.get_role_assignments(colocataires)
+
+    assert chaos == normal_previous
+
+
+def test_should_keep_same_roles_is_deterministic_per_week():
+    """Calling twice in the same week yields the same result — required so reminders/recap agree with /roles."""
+    with patch("src.menage.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = datetime.datetime(2023, 10, 9)
+        first = menage._should_keep_same_roles()
+        second = menage._should_keep_same_roles()
+        assert first == second
 
 
 @patch("src.menage.get_role_assignments", return_value={

--- a/tests/test_menage.py
+++ b/tests/test_menage.py
@@ -42,34 +42,20 @@ def test_get_role_for_person(mock_datetime):
     assert menage.get_role_for_person(colocataires, "Nobody") is None
 
 
-@patch("src.menage.datetime")
-def test_getRoles_changes_every_2_weeks(mock_datetime):
-    colocataires = ["Alice", "Bob", "Charlie", "Diana"]
-
-    mock_datetime.date.return_value = datetime.date(2023, 10, 9)
-    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
-
-    result_week_0 = menage.getRoles(colocataires)
-    assert "CUISINE" in result_week_0
-    assert "Alice" in result_week_0
-
-    # +2 weeks
-    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 23)
-    result_week_2 = menage.getRoles(colocataires)
-    assert "Bob" in result_week_2
-
-    # +4 weeks
-    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 11, 6)
-    result_week_4 = menage.getRoles(colocataires)
-    assert "Charlie" in result_week_4
-
-
 def test_getRoles_has_dechets():
     """DÉCHETS line is present."""
     with patch("src.menage.datetime") as mock_dt:
         mock_dt.datetime.now.return_value = datetime.datetime(2023, 10, 9)
         result = menage.getRoles(["A", "B", "C", "D"])
         assert "DÉCHET" in result
+
+
+@patch("src.menage.datetime")
+def test_getRoles_includes_new_roles_phrase(mock_datetime):
+    from src.phrases import MONDAY_NEW_ROLES
+    mock_datetime.datetime.now.return_value = datetime.datetime(2023, 10, 9)
+    result = menage.getRoles(["A", "B", "C", "D"])
+    assert any(p in result for p in MONDAY_NEW_ROLES)
 
 
 @patch("src.menage.get_role_assignments", return_value={
@@ -107,26 +93,6 @@ def test_getCarteDeLessive_contains_url():
     assert "https://www.lavorent.ch" in result
     assert "100 balles" in result
     assert "carte" in result.lower()
-
-
-@patch("src.menage.is_even_week", return_value=True)
-@patch("src.menage.getRoles", return_value="roles text")
-def test_changeRoles_even_week(mock_getRoles, mock_even):
-    colocataires = ["A", "B", "C", "D"]
-    result = menage.changeRoles(colocataires)
-    assert "Encore une semaine" in result
-    assert "roles text" in result
-    mock_getRoles.assert_called_once_with(colocataires)
-
-
-@patch("src.menage.is_even_week", return_value=False)
-@patch("src.menage.getRoles", return_value="roles text")
-def test_changeRoles_odd_week(mock_getRoles, mock_even):
-    colocataires = ["A", "B", "C", "D"]
-    result = menage.changeRoles(colocataires)
-    assert "Coucou, changement" in result
-    assert "roles text" in result
-    mock_getRoles.assert_called_once_with(colocataires)
 
 
 # --- Sub-task definitions tests ---

--- a/tests/test_menage.py
+++ b/tests/test_menage.py
@@ -144,7 +144,9 @@ def test_cuisine_subtasks():
 
 def test_sdbs_subtasks():
     from src.menage import ROLE_SUBTASKS
-    assert ROLE_SUBTASKS["SDBs"] == ["petit WC", "grand WC", "lavabo", "baignoire"]
+    assert ROLE_SUBTASKS["SDBs"] == [
+        "petit WC", "grand WC", "lavabo", "baignoire", "Vider les petites poubelles",
+    ]
 
 
 def test_sols_subtasks():
@@ -185,7 +187,9 @@ def test_get_subtasks_cuisine():
 def test_get_subtasks_sdbs():
     from src.menage import get_subtasks_for_role
     result = get_subtasks_for_role("SDBs")
-    assert result == ["petit WC", "grand WC", "lavabo", "baignoire"]
+    assert result == [
+        "petit WC", "grand WC", "lavabo", "baignoire", "Vider les petites poubelles",
+    ]
 
 
 def test_get_subtasks_unknown_role_returns_none():

--- a/tests/test_menage.py
+++ b/tests/test_menage.py
@@ -117,16 +117,6 @@ def test_get_carton_reminder(mock_assignments):
     assert "mercredi" in result.lower()
 
 
-@patch("src.menage.get_role_assignments", return_value={
-    "CUISINE": "Alice", "SDBs": "Bob", "SOLs": "Charlie", "DÉCHETS": "Diana"
-})
-def test_getCartonOrPapier(mock_assignments):
-    result = menage.getCartonOrPapier(["Alice", "Bob", "Charlie", "Diana"])
-    assert "Diana" in result
-    assert "lundi" in result.lower()
-    assert "mercredi" in result.lower()
-
-
 def test_getCarteDeLessive_contains_url():
     result = menage.getCarteDeLessive()
     assert "https://www.lavorent.ch" in result


### PR DESCRIPTION
## Summary

  Polishes DrahmstrasseBot's tone and adds a small chaos element to the weekly rotation, plus routes scheduled messages where they belong and prunes dead code uncovered along the way.

  - **Varied, natural phrasing.** New `src/phrases.py` holds curated French phrase pools (Monday roles, Thursday reminder header/done-section/all-done, Sunday recap, stats header/empty).
  Hardcoded strings in `chores.py` and `menage.py` are replaced by `phrases.pick(...)` random draws. Tone matches the existing *ehehe / pouet / coucou* register.
  - **5% chaos week.** On ~1 week in 20 (deterministic per ISO week via seeded `random.Random`) roles don't rotate — everyone keeps last week's role, and the Monday announcement draws from
   a dedicated "mêmes rôles" phrase pool. Determinism is load-bearing: `/roles`, `/papier`, `/carton`, `/reminder`, `/recap` and `/done` all agree with each other within the same week
  without any persisted state. See `.claude/docs/decisions/0001-chaos-week-keeps-roles.md` for the design rationale (kept local, `.claude/` is gitignored).
  - **SDBs "Vider les petites poubelles" subtask.** Fifth subtask added to the bathroom role.
  - **Reminder / recap now land in the main group.** EventBridge targets for the Thursday `/reminder` and Sunday `/recap` were pointing at the dev chat — they now use `prod_chat_id` like
  the other scheduled commands.
  - **Dead code pruned.** `chores.mark_done` (superseded by `toggle_role` + `toggle_subtask` since the inline-keyboard migration), `menage.getCartonOrPapier` (a never-wired transition
  announcement), and a dangling Zürich open-data URL comment in `social.py`, plus their tests.

  ## Commits (bottom-up)

  1. `f11af8c` — fix(infra): route weekly reminder and recap to prod chat
  2. `5dfc92d` — feat(menage): add "Vider les petites poubelles" SDBs subtask
  3. `7074573` — feat: varied natural phrases for bot messages
  4. `f76b2ef` — feat(menage): 5% chaos week where roles don't rotate
  5. `7ed0565` — chore: prune dead code (mark_done, getCartonOrPapier, stale comment)
  6. `97efb7c` — chore: gitignore .config directory

  ## Notes for reviewers

  - `changeRoles()` is gone. It was never called by any handler — the `/roles` handler always routed through `getRoles()`. The Monday prefix now lives inside `getRoles()` directly.
  - The chaos flag uses a fresh `random.Random` instance (not the global RNG) so it doesn't interact with `phrases.pick`'s draws and vice-versa.
  - Two consecutive chaos weeks would drift (probability 0.25%): the second chaos week reproduces the *normal* week `N`, not the shift actually used at `N`. Intentionally not fixed — not
  worth the persisted state.
  - Some `chores.py` branches still handle the pre-subtask DynamoDB format (`{by, at}` directly on the role). Left in place pending a prod-table scan to confirm no such rows remain.
  Follow-up candidate.

  ## Test plan

  - [ ] CI green (lint + pytest).
  - [ ] After deploy, `/roles` in the group shows a varied Monday intro line.
  - [ ] `/done` → SDBs now shows 5 buttons including "Vider les petites poubelles".
  - [ ] Thursday 08:00 UTC: `/reminder` lands in the main group (not dev).
  - [ ] Sunday 19:00 UTC: `/recap` lands in the main group (not dev).
  - [ ] Observe over several weeks that Monday intros vary across runs and occasionally hit a "mêmes rôles" variant.