### PR TITLE
feat: reject unauthenticated webhook calls with Telegram secret_token

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -73,6 +73,7 @@ jobs:
           terraform plan -no-color \
             -var="bot_chat_id=${{ secrets.BOT_CHAT_ID }}" \
             -var="telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
+            -var="telegram_webhook_secret=${{ secrets.TELEGRAM_WEBHOOK_SECRET }}" \
             -out=tfplan
         continue-on-error: true
 
@@ -110,4 +111,4 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           WEBHOOK_URL=$(terraform output -raw webhook_url)
-          curl -sf "https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/setWebhook?url=${WEBHOOK_URL}"
+          curl -sf "https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/setWebhook?url=${WEBHOOK_URL}&secret_token=${{ secrets.TELEGRAM_WEBHOOK_SECRET }}"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Code and infrastructure are deployed separately via GitHub Actions:
 | `AWS_SECRET_ACCESS_KEY` | AWS credentials for deployment |
 | `BOT_CHAT_ID` | Telegram group chat ID |
 | `TELEGRAM_TOKEN` | Telegram bot API token |
+| `TELEGRAM_WEBHOOK_SECRET` | Shared secret verified on every inbound webhook call (any random `A-Za-z0-9_-` string, ≤256 chars) |
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -47,3 +47,56 @@ source .venv/bin/activate
 pip install -r requirements.txt
 pytest
 ```
+
+## Request Flow
+
+What happens when a user types a command in the Telegram chat:
+
+```
+  👤 User in Telegram chat
+   │
+   │ 1. types "/roles"
+   ▼
+  ┌─────────────────────────┐
+  │    Telegram servers     │
+  │   (api.telegram.org)    │
+  └───────────┬─────────────┘
+              │
+              │ 2. POST update JSON to webhook URL
+              │    header: X-Telegram-Bot-Api-Secret-Token  🔒 ②
+              ▼
+  ┌─────────────────────────┐
+  │   AWS API Gateway       │
+  │   POST /webhook         │
+  │   (rate-limited)        │
+  └───────────┬─────────────┘
+              │
+              │ 3. invoke
+              ▼
+  ┌─────────────────────────┐        ┌──────────────┐
+  │   AWS Lambda            │ 4. r/w │  DynamoDB    │
+  │   src.main.lambda_      │◀──────▶│  (chores     │
+  │   handler               │        │   state)     │
+  │                         │        └──────────────┘
+  │   • verify secret 🔒 ②  │
+  │   • dispatch /roles     │
+  │   • build reply         │
+  └───────────┬─────────────┘
+              │
+              │ 5. POST sendMessage
+              │    URL: /bot<TELEGRAM_TOKEN>/sendMessage  🔒 ①
+              ▼
+  ┌─────────────────────────┐
+  │    Telegram servers     │
+  └───────────┬─────────────┘
+              │
+              │ 6. deliver reply
+              ▼
+  👤 User sees bot's answer
+```
+
+**Two secrets, two directions:**
+
+- 🔒 ① `TELEGRAM_TOKEN` — Lambda → Telegram (outbound). Proves "this is my bot" when calling `sendMessage`, `setWebhook`, etc.
+- 🔒 ② `secret_token` on `setWebhook` — Telegram → Lambda (inbound). Telegram sends it as the `X-Telegram-Bot-Api-Secret-Token` header on every webhook call; the Lambda rejects anything without it, so random traffic to the public API Gateway URL can't trigger bot logic.
+

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -11,10 +11,11 @@ resource "aws_lambda_function" "bot" {
 
   environment {
     variables = {
-      TELEGRAM_TOKEN = var.telegram_token
-      BOT_CHAT_ID    = var.bot_chat_id
-      DEV_CHAT_ID    = local.dev_chat_id
-      DYNAMODB_TABLE = aws_dynamodb_table.chores.name
+      TELEGRAM_TOKEN          = var.telegram_token
+      BOT_CHAT_ID             = var.bot_chat_id
+      DEV_CHAT_ID             = local.dev_chat_id
+      DYNAMODB_TABLE          = aws_dynamodb_table.chores.name
+      TELEGRAM_WEBHOOK_SECRET = var.telegram_webhook_secret
     }
   }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,3 +20,9 @@ variable "telegram_token" {
   type        = string
   sensitive   = true
 }
+
+variable "telegram_webhook_secret" {
+  description = "Shared secret used as Telegram's webhook secret_token — verified on every inbound webhook call"
+  type        = string
+  sensitive   = true
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
 import json
 import logging
 import asyncio
+import os
 import traceback
 from src.drahmbot import Drahmbot
+
+TELEGRAM_SECRET_HEADER = "x-telegram-bot-api-secret-token"
 
 # Setup logging
 root = logging.getLogger()
@@ -21,6 +24,21 @@ logger = logging.getLogger(__name__)
 async def handler(event, context):
     logger.info("Lambda invoked")
     logger.info("Received event: %s", event)
+
+    # API Gateway calls carry 'headers'; EventBridge direct invocations don't
+    # and are already authenticated via IAM.
+    if "headers" in event:
+        expected = os.environ.get("TELEGRAM_WEBHOOK_SECRET")
+        if expected:
+            headers = event.get("headers") or {}
+            provided = next(
+                (v for k, v in headers.items() if k.lower() == TELEGRAM_SECRET_HEADER),
+                None,
+            )
+            if provided != expected:
+                logger.warning("Rejected webhook call: invalid or missing secret token")
+                return {"statusCode": 401, "body": json.dumps("unauthorized")}
+
     bot_instance = Drahmbot()
     logger.info("Drahmbot instance retrieved")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,3 +141,69 @@ async def test_lambda_handler_without_body():
 
         mock_bot_instance.process_update.assert_not_called()
         assert response["statusCode"] == 200
+
+
+@pytest.mark.asyncio
+async def test_lambda_handler_webhook_with_valid_secret(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "s3cret")
+    with patch("src.main.Drahmbot") as MockDrahmbot:
+        mock_bot_instance = MockDrahmbot.return_value
+        mock_bot_instance.process_update = AsyncMock()
+        event = {
+            "headers": {"x-telegram-bot-api-secret-token": "s3cret"},
+            "body": '{"update_id": 1, "message": "test"}',
+        }
+
+        response = await main.handler(event, {})
+
+        mock_bot_instance.process_update.assert_called_once()
+        assert response["statusCode"] == 200
+
+
+@pytest.mark.asyncio
+async def test_lambda_handler_webhook_with_wrong_secret_rejected(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "s3cret")
+    with patch("src.main.Drahmbot") as MockDrahmbot:
+        mock_bot_instance = MockDrahmbot.return_value
+        mock_bot_instance.process_update = AsyncMock()
+        event = {
+            "headers": {"x-telegram-bot-api-secret-token": "wrong"},
+            "body": '{"update_id": 1, "message": "test"}',
+        }
+
+        response = await main.handler(event, {})
+
+        mock_bot_instance.process_update.assert_not_called()
+        assert response["statusCode"] == 401
+
+
+@pytest.mark.asyncio
+async def test_lambda_handler_webhook_without_secret_header_rejected(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "s3cret")
+    with patch("src.main.Drahmbot") as MockDrahmbot:
+        mock_bot_instance = MockDrahmbot.return_value
+        mock_bot_instance.process_update = AsyncMock()
+        event = {
+            "headers": {"content-type": "application/json"},
+            "body": '{"update_id": 1, "message": "test"}',
+        }
+
+        response = await main.handler(event, {})
+
+        mock_bot_instance.process_update.assert_not_called()
+        assert response["statusCode"] == 401
+
+
+@pytest.mark.asyncio
+async def test_lambda_handler_eventbridge_skips_secret_check(monkeypatch):
+    """EventBridge events have no 'headers' and must pass through without a secret."""
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "s3cret")
+    with patch("src.main.Drahmbot") as MockDrahmbot:
+        mock_bot_instance = MockDrahmbot.return_value
+        mock_bot_instance.process_update = AsyncMock()
+        event = {"body": '{"update_id": 1, "message": "test"}'}  # no 'headers' key
+
+        response = await main.handler(event, {})
+
+        mock_bot_instance.process_update.assert_called_once()
+        assert response["statusCode"] == 200


### PR DESCRIPTION
## Summary

Closes a cost/abuse hole: right now anyone who knows the API Gateway URL can `curl -X POST .../webhook -d '{}'` and trigger a Lambda invocation. Verified reproducible
 on prod — returns `"ok"`.

This PR adds Telegram's [`secret_token`](https://core.telegram.org/bots/api#setwebhook) mechanism end-to-end:

- A shared secret `TELEGRAM_WEBHOOK_SECRET` flows from GitHub Secrets → Terraform → Lambda env var.
- The infra workflow re-registers the webhook with `&secret_token=...`, so Telegram sends it on every call as the `X-Telegram-Bot-Api-Secret-Token` header.
- The Lambda rejects any API Gateway call with a missing or mismatched header (`401 unauthorized`) **before** any bot logic runs.
- EventBridge direct invocations have no `headers` field and keep bypassing the check — they're already IAM-authenticated.

Also includes a previous commit that adds a request-flow diagram to the README illustrating where the two secrets (`TELEGRAM_TOKEN` outbound, `secret_token` inbound)
fit.

## Prerequisite

A new GitHub repository secret **`TELEGRAM_WEBHOOK_SECRET`** must exist before this merges. Any random `A-Za-z0-9_-` string, ≤256 chars. Suggested generator:

```bash
  python3 -c "import secrets; print(secrets.token_urlsafe(32))"
```

## Changes

| File | Change |
|---|---|
| `infra/variables.tf` | New sensitive `telegram_webhook_secret` variable |
| `infra/lambda.tf` | Pass it as `TELEGRAM_WEBHOOK_SECRET` env var to the Lambda |
| `.github/workflows/infra.yml` | Pipe the GitHub secret into Terraform; append `&secret_token=...` to `setWebhook` |
| `src/main.py` | Header check at the top of `handler` — returns `401` on mismatch |
| `tests/test_main.py` | Cover valid / invalid / missing header, and EventBridge pass-through |
| `README.md` | Request-flow diagram + `TELEGRAM_WEBHOOK_SECRET` added to required-secrets table |

## Deploy ordering

`terraform apply` runs **before** `setWebhook` in the workflow, so the Lambda receives the new env var before Telegram starts sending the header — no stale window.

## Test plan

- [x] `TELEGRAM_WEBHOOK_SECRET` GitHub secret is set
- [x] `terraform plan` on this PR renders cleanly (no unexpected resource changes besides the env var)
- [x] After merge, infra workflow's `Set Telegram webhook` step succeeds
- [ ] `curl -s "https://api.telegram.org/bot<TOKEN>/getWebhookInfo" \| jq '.result.has_custom_certificate, .result.pending_update_count'` shows the webhook is
registered
- [x] Send a real message in the Telegram chat → bot replies normally
- [x] `curl -i -X POST "<webhook_url>" -H 'Content-Type: application/json' -d '{}'` → returns `401`
- [x] `curl -i -X POST "<webhook_url>" -H 'X-Telegram-Bot-Api-Secret-Token: wrong' -d '{}'` → returns `401`
- [x] EventBridge-triggered command (e.g. `/reminder` on Thursday 08:00 UTC, or manually invoke the rule) still works

## Follow-ups (not in this PR)

Still worth adding as cost defense-in-depth:
- API Gateway throttling (burst/rate limits on the route)
- Lambda reserved concurrency cap
- AWS Budget alarm + CloudWatch alarm on `Invocations`