### PR TITLE
feat: add API Gateway throttling and cost/abuse monitoring

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -74,6 +74,7 @@ jobs:
             -var="bot_chat_id=${{ secrets.BOT_CHAT_ID }}" \
             -var="telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
             -var="telegram_webhook_secret=${{ secrets.TELEGRAM_WEBHOOK_SECRET }}" \
+            -var="alert_email=${{ secrets.ALERT_EMAIL }}" \
             -out=tfplan
         continue-on-error: true
 

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Comment PR with plan
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const output = `#### Terraform Plan \`${{ steps.plan.outcome }}\`

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Code and infrastructure are deployed separately via GitHub Actions:
 | `BOT_CHAT_ID` | Telegram group chat ID |
 | `TELEGRAM_TOKEN` | Telegram bot API token |
 | `TELEGRAM_WEBHOOK_SECRET` | Shared secret verified on every inbound webhook call (any random `A-Za-z0-9_-` string, ≤256 chars) |
+| `ALERT_EMAIL` | Email that receives AWS Budget and CloudWatch alarm notifications |
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Code and infrastructure are deployed separately via GitHub Actions:
 | `BOT_CHAT_ID` | Telegram group chat ID |
 | `TELEGRAM_TOKEN` | Telegram bot API token |
 | `TELEGRAM_WEBHOOK_SECRET` | Shared secret verified on every inbound webhook call (any random `A-Za-z0-9_-` string, ≤256 chars) |
+| `ALERT_EMAIL` | Email that receives AWS Budget and CloudWatch alarm notifications |
 
 ## Local Development
 

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -7,6 +7,11 @@ resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.webhook.id
   name        = "$default"
   auto_deploy = true
+
+  default_route_settings {
+    throttling_burst_limit = 5
+    throttling_rate_limit  = 2
+  }
 }
 
 resource "aws_apigatewayv2_integration" "lambda" {

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,0 +1,55 @@
+resource "aws_sns_topic" "alerts" {
+  name = "drahmstrassebot-alerts"
+}
+
+resource "aws_sns_topic_subscription" "alerts_email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# Fires when Lambda is invoked more than 50 times in 5 minutes — abuse signal.
+# Normal traffic is a handful of invocations per window (EventBridge schedules + coloc messages).
+resource "aws_cloudwatch_metric_alarm" "lambda_invocations_spike" {
+  alarm_name          = "drahmstrassebot-invocations-spike"
+  alarm_description   = "Lambda invoked >50 times in 5 minutes — possible abuse"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Invocations"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 50
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.bot.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = "drahmstrassebot-monthly"
+  budget_type  = "COST"
+  limit_amount = "5"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.alert_email]
+  }
+}

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -8,11 +8,11 @@ resource "aws_sns_topic_subscription" "alerts_email" {
   endpoint  = var.alert_email
 }
 
-# Fires when Lambda is invoked more than 50 times in 5 minutes — abuse signal.
+# Fires when Lambda is invoked more than 50 times in 5 minutes, an abuse signal.
 # Normal traffic is a handful of invocations per window (EventBridge schedules + coloc messages).
 resource "aws_cloudwatch_metric_alarm" "lambda_invocations_spike" {
   alarm_name          = "drahmstrassebot-invocations-spike"
-  alarm_description   = "Lambda invoked >50 times in 5 minutes — possible abuse"
+  alarm_description   = "Lambda invoked >50 times in 5 minutes, possible abuse"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "Invocations"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -26,3 +26,8 @@ variable "telegram_webhook_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "alert_email" {
+  description = "Email address that receives AWS Budget and CloudWatch alarm notifications"
+  type        = string
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -30,4 +30,5 @@ variable "telegram_webhook_secret" {
 variable "alert_email" {
   description = "Email address that receives AWS Budget and CloudWatch alarm notifications"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
## Summary

Follow-up to #31. The `secret_token` closed the "random internet attacker" vector, but a legitimate group member (or anyone who can DM the bot) could still spam
commands and run up the bill. This PR adds three layers of defense-in-depth:

1. **API Gateway throttling** — 2 rps sustained, 5-request burst on the `$default` stage. Excess requests return `429` at the gateway, never reaching Lambda. Since
real traffic is a handful of invocations per day, this ceiling is very safe.
2. **CloudWatch alarm on Lambda invocations** — fires when `Sum(Invocations) > 50` in a 5-minute window. Notifies via SNS → email.
3. **Monthly AWS Budget** — $5 cap, emails at 80% actual and 100% forecasted.

## Prerequisite

A new GitHub repository secret **`ALERT_EMAIL`** must exist before this merges — the email that receives budget and alarm notifications.

After the first apply, **AWS will send a confirmation email to that address** for the SNS subscription. The CloudWatch alarm won't deliver until the link is clicked.
Budget notifications don't need confirmation.

## Changes

| File | Change |
|---|---|
| `infra/api_gateway.tf` | `default_route_settings` block on the stage with burst=5, rate=2 |
| `infra/monitoring.tf` | **new** — SNS topic + email subscription, `Invocations` alarm, monthly budget |
| `infra/variables.tf` | New `alert_email` variable |
| `.github/workflows/infra.yml` | Pass `ALERT_EMAIL` secret into Terraform |
| `README.md` | Add `ALERT_EMAIL` to required-secrets table |

## Test plan

- [ ] `ALERT_EMAIL` GitHub secret is set
- [ ] `terraform plan` on this PR shows: `aws_apigatewayv2_stage.default` updated in place, 3 new resources (`aws_sns_topic`, `aws_sns_topic_subscription`,
`aws_cloudwatch_metric_alarm`, `aws_budgets_budget`), no destroys
- [ ] After apply, confirm the SNS subscription from the email AWS sends
- [ ] Budget visible in AWS Console → Billing → Budgets
- [ ] Alarm visible in AWS Console → CloudWatch → Alarms, state `OK`
- [ ] Bot still responds to a real Telegram message (throttling doesn't break golden path)
- [ ] Flood test: `for i in {1..20}; do curl -s -o /dev/null -w "%{http_code}\n" -X POST "<webhook_url>" -d '{}' & done; wait` — expect a mix of `401` (auth
rejection) and `429` (gateway throttling). The `429`s prove throttling is active.

## Thresholds — calibration notes

Both values are first guesses, easy to tune later:

- **Alarm at 50 invocations / 5 min**: normal traffic is typically 0–5 per window. 50 is a strong abuse signal with ~zero false-positive risk. If it ever fires
spuriously during a legitimate traffic pattern we haven't seen, raise it.
- **Budget at $5/month**: today the bot costs pennies. $5 is a canary, not a hard cap. AWS Budgets only notify — they don't stop resources.

## Follow-ups (not in this PR)

Still worth adding eventually, but lower priority now that the above is in place:

- Lambda reserved concurrency cap
- Chat-ID allowlist in the Lambda (reject updates not from the flat's group)
- Disable DMs to the bot via BotFather