### PR TITLE
feat: add /arrosage daily plant-watering reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Telegram bot for a shared flat — handles chore assignments, dinner polls, and 
 | `/papier` | Monday 19:00 UTC | Paper/cardboard recycling reminder |
 | `/whoishere` | Weekdays 15:00 UTC | Dinner attendance poll |
 | `/lessive` | Manual | Laundry card info |
+| `/arrosage` | Daily 07:00 UTC | Plant watering vote (silent if Zürich forecast ≤ 25°C) |
 
 ## Architecture
 

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -33,6 +33,11 @@ locals {
       description = "Weekly chore recap (Sunday 19:00 UTC)"
       command     = "/recap@DrahmstrasseBot"
     }
+    arrosage = {
+      schedule    = "cron(0 7 * * ? *)"
+      description = "Plant watering reminder (daily 07:00 UTC, skipped if cool)"
+      command     = "/arrosage@DrahmstrasseBot"
+    }
   }
 }
 
@@ -157,6 +162,27 @@ resource "aws_cloudwatch_event_target" "recap" {
         chat = { id = tonumber(local.prod_chat_id) }
         text = local.schedules.recap.command
         entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.recap.command) }]
+      }
+    })
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "arrosage" {
+  name                = "arrosage"
+  description         = local.schedules.arrosage.description
+  schedule_expression = local.schedules.arrosage.schedule
+}
+
+resource "aws_cloudwatch_event_target" "arrosage" {
+  rule = aws_cloudwatch_event_rule.arrosage.name
+  arn  = aws_lambda_function.bot.arn
+
+  input = jsonencode({
+    body = jsonencode({
+      message = {
+        chat = { id = tonumber(local.prod_chat_id) }
+        text = local.schedules.arrosage.command
+        entities = [{ type = "bot_command", offset = 0, length = length(local.schedules.arrosage.command) }]
       }
     })
   })

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -81,3 +81,11 @@ resource "aws_lambda_permission" "eventbridge_recap" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.recap.arn
 }
+
+resource "aws_lambda_permission" "eventbridge_arrosage" {
+  statement_id  = "AllowEventBridgeArrosage"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bot.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.arrosage.arn
+}

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import random
 import telebot
 
 from telebot.async_telebot import AsyncTeleBot
@@ -9,6 +10,9 @@ import src.utils as utils
 import src.menage as menage
 import src.social as social
 import src.chores as chores
+import src.phrases as phrases
+import src.plants as plants
+import src.weather as weather
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -96,6 +100,42 @@ def _build_done_text(role, person):
         if done_count == total:
             return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites \u2705"
         return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites."
+
+
+def _build_plants_keyboard(date_iso, current_state):
+    """Two-button radio for the daily watering vote."""
+    keyboard = telebot.types.InlineKeyboardMarkup()
+    options = [
+        (plants.STATE_NEEDS_WATER, phrases.ARROSAGE_LABEL_NEEDS),
+        (plants.STATE_OK, phrases.ARROSAGE_LABEL_OK),
+    ]
+    for state, label in options:
+        icon = "✅" if state == current_state else "⬜"
+        keyboard.add(telebot.types.InlineKeyboardButton(
+            text=f"{icon} {label}",
+            callback_data=f"plants:{date_iso}:{state}",
+        ))
+    return keyboard
+
+
+def _pick_arrosage_header(date_iso):
+    """Pick a header phrase deterministically per date so edits stay stable."""
+    rng = random.Random(f"drahmbot-arrosage-{date_iso}")
+    return rng.choice(phrases.ARROSAGE_HEADER)
+
+
+def _build_plants_text(date_iso, temp_c, state_data):
+    """Build status text for the watering message."""
+    header = _pick_arrosage_header(date_iso).format(temp=round(temp_c))
+    if not state_data:
+        return header
+    state = state_data.get("state")
+    by = state_data.get("by", "?")
+    if state == plants.STATE_NEEDS_WATER:
+        return f"{header}\n\n\U0001f4a7 {by} dit : faut arroser !"
+    if state == plants.STATE_OK:
+        return f"{header}\n\n\U0001f4aa {by} dit : ça survit un jour de +."
+    return header
 
 
 class Drahmbot:
@@ -285,6 +325,74 @@ class Drahmbot:
             assignments = menage.get_role_assignments(colocataires)
             answer = chores.get_sunday_recap(assignments)
             await self.bot.send_message(message.chat.id, answer)
+
+        @self.bot.message_handler(commands=['arrosage'])
+        async def send_arrosage(message):
+            logger.info("Command /arrosage received from %s", message.chat.id)
+            max_temp = weather.get_zurich_max_temp_today()
+            if max_temp is None or max_temp < weather.HOT_THRESHOLD_C:
+                logger.info("Skipping arrosage: max_temp=%s threshold=%s",
+                            max_temp, weather.HOT_THRESHOLD_C)
+                return
+            today_iso = datetime.date.today().isoformat()
+            state_data = plants.get_today_state()
+            current_state = state_data.get("state") if state_data else None
+            keyboard = _build_plants_keyboard(today_iso, current_state)
+            text = _build_plants_text(today_iso, max_temp, state_data)
+            await self.bot.send_message(message.chat.id, text, reply_markup=keyboard)
+            logger.info("Sent arrosage message (max_temp=%.1f)", max_temp)
+
+        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("plants:"))
+        async def handle_plants_callback(call):
+            parts = call.data.split(":")
+            if len(parts) != 3:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+
+            date_iso = parts[1]
+            new_state = parts[2]
+
+            today_iso = datetime.date.today().isoformat()
+            if date_iso != today_iso:
+                await self.bot.answer_callback_query(
+                    call.id, "Trop tard, le vote d'arrosage est clos.", show_alert=True,
+                )
+                return
+
+            user_id = call.from_user.id
+            person = TELEGRAM_USER_MAP.get(user_id)
+            if not person:
+                await self.bot.answer_callback_query(
+                    call.id, "Tu n'es pas reconnu.", show_alert=True,
+                )
+                return
+
+            if new_state not in plants.VALID_STATES:
+                await self.bot.answer_callback_query(
+                    call.id, "Choix inconnu.", show_alert=True,
+                )
+                return
+
+            state_data = plants.set_today_state(new_state, person)
+            toast = "Noté, faut arroser !" if new_state == plants.STATE_NEEDS_WATER \
+                else "Noté, ça survit !"
+
+            # Re-read the temperature for the message. Cheap enough; if it fails
+            # we just rebuild without the header refreshing — the existing
+            # message text already has it, but we need *something* to pass.
+            max_temp = weather.get_zurich_max_temp_today()
+            if max_temp is None:
+                max_temp = weather.HOT_THRESHOLD_C  # fallback so format() works
+
+            keyboard = _build_plants_keyboard(date_iso, new_state)
+            text = _build_plants_text(date_iso, max_temp, state_data)
+            await self.bot.edit_message_text(
+                text,
+                call.message.chat.id,
+                call.message.message_id,
+                reply_markup=keyboard,
+            )
+            await self.bot.answer_callback_query(call.id, toast)
 
         @self.bot.message_handler(commands=['stats'])
         async def send_stats(message):

--- a/src/phrases.py
+++ b/src/phrases.py
@@ -116,6 +116,18 @@ STATS_EMPTY = [
     "C'est le désert niveau stats, bougez-vous ehehe",
 ]
 
+ARROSAGE_HEADER = [
+    "🌡️ {temp}°C aujourd'hui à Zürich. Les plantes vous regardent.",
+    "Yo, il va faire {temp}°C aujourd'hui. Pensez aux plantes.",
+    "🌵 Annoncé : {temp}°C. Spoiler : c'est chaud pour la verdure.",
+    "{temp}°C prévus à Zürich. Faut décider du sort des plantes.",
+    "Alerte canicule à {temp}°C : les plantes ont (peut-être) soif.",
+    "Il va cogner aujourd'hui : {temp}°C. On arrose ou on parie ?",
+]
+
+ARROSAGE_LABEL_NEEDS = "Ouaiiiis faut arroser tout crève là aled !!"
+ARROSAGE_LABEL_OK = "TOUT BON CA SURVIT UN JOUR DE +"
+
 
 def pick(phrases):
     """Return a random phrase from the given list."""

--- a/src/plants.py
+++ b/src/plants.py
@@ -1,0 +1,59 @@
+import datetime
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+STATE_NEEDS_WATER = "needs"
+STATE_OK = "ok"
+VALID_STATES = (STATE_NEEDS_WATER, STATE_OK)
+
+# Reuses the chores table. The key field is named `week_key` but DynamoDB
+# treats it as an opaque string. Prefix `plant:` keeps these rows distinct
+# from chore rows (`2026-W14`) so `chores.get_stats` ignores them naturally.
+PLANT_KEY_PREFIX = "plant:"
+
+_table = None
+
+
+def _get_table():
+    global _table
+    if _table is None:
+        table_name = os.environ.get("DYNAMODB_TABLE", "drahmstrassebot-chores")
+        dynamodb = boto3.resource("dynamodb")
+        _table = dynamodb.Table(table_name)
+        logger.info("Initialized DynamoDB table (plants): %s", table_name)
+    return _table
+
+
+def today_key() -> str:
+    return f"{PLANT_KEY_PREFIX}{datetime.date.today().isoformat()}"
+
+
+def get_today_state() -> dict:
+    """Return today's watering state, or empty dict if no one has voted yet.
+
+    Format: {"state": "needs"|"ok", "by": person, "at": iso_ts}
+    """
+    table = _get_table()
+    response = table.get_item(Key={"week_key": today_key()})
+    item = response.get("Item", {})
+    return item.get("watering", {})
+
+
+def set_today_state(state: str, person: str) -> dict:
+    """Set today's watering state, overwriting any prior vote. Returns the new state."""
+    if state not in VALID_STATES:
+        raise ValueError(f"Invalid state: {state}")
+    table = _get_table()
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    watering = {"state": state, "by": person, "at": now}
+    table.update_item(
+        Key={"week_key": today_key()},
+        UpdateExpression="SET watering = :val",
+        ExpressionAttributeValues={":val": watering},
+    )
+    logger.info("Plant watering: state=%s by=%s key=%s", state, person, today_key())
+    return watering

--- a/src/weather.py
+++ b/src/weather.py
@@ -1,0 +1,33 @@
+import json
+import logging
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+ZURICH_LAT = 47.37
+ZURICH_LON = 8.55
+HOT_THRESHOLD_C = 25.0
+HTTP_TIMEOUT_S = 2.0
+
+OPEN_METEO_URL = (
+    "https://api.open-meteo.com/v1/forecast"
+    f"?latitude={ZURICH_LAT}&longitude={ZURICH_LON}"
+    "&daily=temperature_2m_max"
+    "&timezone=Europe%2FZurich"
+    "&forecast_days=1"
+)
+
+
+def get_zurich_max_temp_today():
+    """Return today's forecast max temperature in Zurich (°C), or None on failure.
+
+    Returning None lets callers skip silently rather than crash the Lambda.
+    """
+    try:
+        with urllib.request.urlopen(OPEN_METEO_URL, timeout=HTTP_TIMEOUT_S) as resp:
+            payload = json.loads(resp.read())
+        return float(payload["daily"]["temperature_2m_max"][0])
+    except (urllib.error.URLError, ValueError, KeyError, IndexError, TypeError) as e:
+        logger.warning("Open-Meteo fetch failed: %s", e)
+        return None

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -41,9 +41,19 @@ def _capture_handlers(bot):
         return wrapper
 
     def capture_callback_handler(*args, **kwargs):
-        def wrapper(func):
-            handlers["_callback_query"] = func
-            return func
+        func_filter = kwargs.get("func")
+
+        def wrapper(handler_fn):
+            pairs = handlers.setdefault("_callback_pairs", [])
+            pairs.append((func_filter, handler_fn))
+
+            async def dispatcher(call):
+                for filt, h in handlers["_callback_pairs"]:
+                    if filt is None or filt(call):
+                        return await h(call)
+
+            handlers["_callback_query"] = dispatcher
+            return handler_fn
         return wrapper
 
     bot.bot.message_handler = capture_message_handler

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from src.drahmbot import (
     Drahmbot, ColocAccessMiddleware, TELEGRAM_USER_MAP, colocataires,
     _build_done_keyboard, _build_done_text,
+    _build_plants_keyboard, _build_plants_text,
 )
 
 @pytest.mark.asyncio
@@ -582,6 +583,267 @@ async def test_callback_wrong_user(mock_group, mock_token, mock_dt, mock_role):
         await handlers["_callback_query"](call)
         toast = bot.bot.answer_callback_query.call_args
         assert "pas ta tâche" in toast[0][1]
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+# --- /arrosage tests ---
+
+
+def test_build_plants_keyboard_no_vote():
+    kb = _build_plants_keyboard("2026-06-01", None)
+    assert len(kb.keyboard) == 2
+    assert "⬜" in kb.keyboard[0][0].text
+    assert "⬜" in kb.keyboard[1][0].text
+    assert kb.keyboard[0][0].callback_data == "plants:2026-06-01:needs"
+    assert kb.keyboard[1][0].callback_data == "plants:2026-06-01:ok"
+
+
+def test_build_plants_keyboard_needs_selected():
+    kb = _build_plants_keyboard("2026-06-01", "needs")
+    assert "✅" in kb.keyboard[0][0].text  # needs row selected
+    assert "⬜" in kb.keyboard[1][0].text  # ok row not selected
+
+
+def test_build_plants_keyboard_ok_selected():
+    kb = _build_plants_keyboard("2026-06-01", "ok")
+    assert "⬜" in kb.keyboard[0][0].text
+    assert "✅" in kb.keyboard[1][0].text
+
+
+def test_build_plants_text_no_vote():
+    text = _build_plants_text("2026-06-01", 28.0, {})
+    assert "28" in text  # rounded temp present
+
+
+def test_build_plants_text_header_stable_across_calls():
+    a = _build_plants_text("2026-06-01", 28.0, {})
+    b = _build_plants_text("2026-06-01", 28.0, {})
+    assert a == b
+
+
+def test_build_plants_text_with_needs_vote():
+    text = _build_plants_text(
+        "2026-06-01", 28.0,
+        {"state": "needs", "by": "Léa", "at": "..."},
+    )
+    assert "Léa" in text
+    assert "arroser" in text.lower()
+
+
+def test_build_plants_text_with_ok_vote():
+    text = _build_plants_text(
+        "2026-06-01", 28.0,
+        {"state": "ok", "by": "Timon", "at": "..."},
+    )
+    assert "Timon" in text
+    assert "survit" in text.lower()
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.plants.get_today_state", return_value={})
+@patch("src.drahmbot.weather.get_zurich_max_temp_today", return_value=28.4)
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_arrosage_hot_day_sends_message(
+    mock_group, mock_token, mock_temp, mock_state,
+):
+    bot = Drahmbot()
+    bot.bot.send_message = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    message = MagicMock()
+    message.chat.id = 999
+
+    await handlers["arrosage"](message)
+    bot.bot.send_message.assert_called_once()
+    call_args = bot.bot.send_message.call_args
+    assert call_args[0][0] == 999
+    assert "reply_markup" in call_args[1]
+    kb = call_args[1]["reply_markup"]
+    assert len(kb.keyboard) == 2
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.weather.get_zurich_max_temp_today", return_value=18.0)
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_arrosage_cool_day_silent(mock_group, mock_token, mock_temp):
+    bot = Drahmbot()
+    bot.bot.send_message = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    message = MagicMock()
+    message.chat.id = 999
+
+    await handlers["arrosage"](message)
+    bot.bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.weather.get_zurich_max_temp_today", return_value=None)
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_arrosage_weather_unavailable_silent(mock_group, mock_token, mock_temp):
+    bot = Drahmbot()
+    bot.bot.send_message = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    message = MagicMock()
+    message.chat.id = 999
+
+    await handlers["arrosage"](message)
+    bot.bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.weather.get_zurich_max_temp_today", return_value=29.0)
+@patch("src.drahmbot.plants.set_today_state",
+       return_value={"state": "needs", "by": "Léa", "at": "..."})
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_plants_callback_sets_needs(
+    mock_group, mock_token, mock_dt, mock_set, mock_temp,
+):
+    mock_dt.date.today.return_value.isoformat.return_value = "2026-06-01"
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Léa"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "plants:2026-06-01:needs"
+        call.from_user.id = 42
+        call.id = "cbp1"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_set.assert_called_once_with("needs", "Léa")
+        bot.bot.edit_message_text.assert_called_once()
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "arroser" in toast.lower()
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.weather.get_zurich_max_temp_today", return_value=29.0)
+@patch("src.drahmbot.plants.set_today_state",
+       return_value={"state": "ok", "by": "Timon", "at": "..."})
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_plants_callback_sets_ok(
+    mock_group, mock_token, mock_dt, mock_set, mock_temp,
+):
+    mock_dt.date.today.return_value.isoformat.return_value = "2026-06-01"
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "plants:2026-06-01:ok"
+        call.from_user.id = 42
+        call.id = "cbp2"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_set.assert_called_once_with("ok", "Timon")
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "survit" in toast.lower()
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.plants.set_today_state")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_plants_callback_stale_date(mock_group, mock_token, mock_dt, mock_set):
+    mock_dt.date.today.return_value.isoformat.return_value = "2026-06-02"
+
+    bot = Drahmbot()
+    bot.bot.answer_callback_query = AsyncMock()
+    bot.bot.edit_message_text = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    call = MagicMock()
+    call.data = "plants:2026-06-01:needs"  # yesterday's vote
+    call.from_user.id = 891406979
+    call.id = "cbp3"
+
+    await handlers["_callback_query"](call)
+    mock_set.assert_not_called()
+    toast = bot.bot.answer_callback_query.call_args
+    assert "Trop tard" in toast[0][1]
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.plants.set_today_state")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_plants_callback_unknown_user(mock_group, mock_token, mock_dt, mock_set):
+    mock_dt.date.today.return_value.isoformat.return_value = "2026-06-01"
+
+    bot = Drahmbot()
+    bot.bot.answer_callback_query = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    call = MagicMock()
+    call.data = "plants:2026-06-01:ok"
+    call.from_user.id = 99999  # not in TELEGRAM_USER_MAP
+    call.id = "cbp4"
+
+    await handlers["_callback_query"](call)
+    mock_set.assert_not_called()
+    toast = bot.bot.answer_callback_query.call_args
+    assert "reconnu" in toast[0][1]
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.plants.set_today_state")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_plants_callback_invalid_state(mock_group, mock_token, mock_dt, mock_set):
+    mock_dt.date.today.return_value.isoformat.return_value = "2026-06-01"
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Léa"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "plants:2026-06-01:maybe"
+        call.from_user.id = 42
+        call.id = "cbp5"
+
+        await handlers["_callback_query"](call)
+        mock_set.assert_not_called()
+        toast = bot.bot.answer_callback_query.call_args
+        assert "inconnu" in toast[0][1]
     finally:
         drahmbot_module.TELEGRAM_USER_MAP.clear()
         drahmbot_module.TELEGRAM_USER_MAP.update(original_map)

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src import plants
+
+
+@pytest.fixture(autouse=True)
+def reset_table_cache():
+    plants._table = None
+    yield
+    plants._table = None
+
+
+@patch("src.plants.today_key", return_value="plant:2026-06-01")
+@patch("src.plants._get_table")
+def test_get_today_state_empty(mock_get_table, _key):
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {}
+    mock_get_table.return_value = mock_table
+
+    assert plants.get_today_state() == {}
+
+
+@patch("src.plants.today_key", return_value="plant:2026-06-01")
+@patch("src.plants._get_table")
+def test_get_today_state_with_data(mock_get_table, _key):
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "week_key": "plant:2026-06-01",
+            "watering": {"state": "needs", "by": "Léa", "at": "2026-06-01T08:00:00+00:00"},
+        }
+    }
+    mock_get_table.return_value = mock_table
+
+    state = plants.get_today_state()
+    assert state["state"] == "needs"
+    assert state["by"] == "Léa"
+
+
+@patch("src.plants.today_key", return_value="plant:2026-06-01")
+@patch("src.plants._get_table")
+def test_set_today_state_needs(mock_get_table, _key):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = plants.set_today_state(plants.STATE_NEEDS_WATER, "Alexis")
+    assert result["state"] == "needs"
+    assert result["by"] == "Alexis"
+    assert "at" in result
+    mock_table.update_item.assert_called_once()
+    call = mock_table.update_item.call_args[1]
+    assert call["Key"] == {"week_key": "plant:2026-06-01"}
+    assert "SET watering" in call["UpdateExpression"]
+
+
+@patch("src.plants.today_key", return_value="plant:2026-06-01")
+@patch("src.plants._get_table")
+def test_set_today_state_ok(mock_get_table, _key):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    result = plants.set_today_state(plants.STATE_OK, "Timon")
+    assert result["state"] == "ok"
+
+
+def test_set_today_state_invalid():
+    with pytest.raises(ValueError):
+        plants.set_today_state("maybe", "Alexis")
+
+
+def test_today_key_format():
+    key = plants.today_key()
+    assert key.startswith("plant:")
+    # Format YYYY-MM-DD
+    date_part = key.split(":", 1)[1]
+    parts = date_part.split("-")
+    assert len(parts) == 3
+    assert len(parts[0]) == 4

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,47 @@
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+from src import weather
+
+
+def _fake_resp(payload):
+    body = io.BytesIO(json.dumps(payload).encode())
+
+    class _Ctx:
+        def __enter__(self_inner):
+            return body
+
+        def __exit__(self_inner, *a):
+            return False
+
+    return _Ctx()
+
+
+@patch("src.weather.urllib.request.urlopen")
+def test_get_zurich_max_temp_today_ok(mock_urlopen):
+    mock_urlopen.return_value = _fake_resp({
+        "daily": {"temperature_2m_max": [28.4]}
+    })
+    assert weather.get_zurich_max_temp_today() == 28.4
+
+
+@patch("src.weather.urllib.request.urlopen")
+def test_get_zurich_max_temp_today_network_error(mock_urlopen):
+    mock_urlopen.side_effect = urllib.error.URLError("boom")
+    assert weather.get_zurich_max_temp_today() is None
+
+
+@patch("src.weather.urllib.request.urlopen")
+def test_get_zurich_max_temp_today_malformed(mock_urlopen):
+    mock_urlopen.return_value = _fake_resp({"daily": {}})
+    assert weather.get_zurich_max_temp_today() is None
+
+
+@patch("src.weather.urllib.request.urlopen")
+def test_get_zurich_max_temp_today_empty_array(mock_urlopen):
+    mock_urlopen.return_value = _fake_resp({
+        "daily": {"temperature_2m_max": []}
+    })
+    assert weather.get_zurich_max_temp_today() is None


### PR DESCRIPTION
## Summary
- New `/arrosage` command: daily 07:00 UTC EventBridge trigger fetches Zürich's max temp from Open-Meteo (stdlib `urllib`, no API key); below 25 °C or on weather API failure, the bot stays silent.
- Two-button radio (`Ouaiiiis faut arroser…` / `TOUT BON CA SURVIT…`) with vote persisted in the existing chores DynamoDB table under a `plant:YYYY-MM-DD` key. Any colocataire can vote; later votes overwrite earlier ones.
- Header phrase is picked deterministically per date so message edits don't re-roll the wording.

## Test plan
- [x] `pytest tests/test_weather.py tests/test_plants.py tests/test_drahmbot.py` passes locally / in CI
- [ ] `terraform plan` in `infra/` shows the new EventBridge rule + Lambda permission as the only additions
- [ ] After deploy, manually `/arrosage` in the dev chat on a hot day to confirm
message+keyboard; click each button to verify state edits in place
- [ ] On a cool day (or by lowering the threshold temporarily), confirm the bot stays silent