### PR TITLE
feat: add reset button to counter subtasks

### DIFF
--- a/src/chores.py
+++ b/src/chores.py
@@ -155,6 +155,22 @@ def increment_subtask_counter(role: str, subtask: str, person: str) -> int:
     return new_count
 
 
+def reset_subtask_counter(role: str, subtask: str) -> None:
+    """Reset a counter-style sub-task's count back to 0 for everyone this
+    week. No confirmation needed: an accidental reset is trivially undone by
+    re-pressing +1 the same number of times."""
+    table = _get_table()
+    week_key = _current_week_key()
+
+    table.update_item(
+        Key={"week_key": week_key},
+        UpdateExpression="SET completed.#role.subtasks.#subtask = :empty_counter",
+        ExpressionAttributeNames={"#role": role, "#subtask": subtask},
+        ExpressionAttributeValues={":empty_counter": {"count": 0}},
+    )
+    logger.info("Reset %s.%s counter to 0 for %s", role, subtask, week_key)
+
+
 def is_subtask_satisfied(sub_data: dict) -> bool:
     """Whether a subtask entry counts as done: any entry for a toggle subtask,
     count >= 1 for a counter subtask (see menage.COUNTER_SUBTASKS)."""

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -184,12 +184,19 @@ def _build_subtask_text(role, subtask, assigned_person, sub_data):
 
 
 def _build_counter_keyboard(week_num, cmd, count):
-    """Single +1 button for a counter-style subtask (e.g. /plandetravail)."""
+    """+1 button for a counter-style subtask (e.g. /plandetravail), plus a
+    reset button once there's something to reset. No confirmation step:
+    resetting by mistake just means re-pressing +1 to recover the count."""
     keyboard = telebot.types.InlineKeyboardMarkup()
     keyboard.add(telebot.types.InlineKeyboardButton(
         text=f"➕ +1 (fait {count}x cette semaine)",
         callback_data=f"counter:{week_num}:{cmd}",
     ))
+    if count > 0:
+        keyboard.add(telebot.types.InlineKeyboardButton(
+            text="🔄 Remettre à 0",
+            callback_data=f"resetcounter:{week_num}:{cmd}",
+        ))
     return keyboard
 
 
@@ -717,6 +724,37 @@ class Drahmbot:
             assigned_person = assignments.get(role, "?")
             text = _build_counter_text(role, subtask, assigned_person, new_count)
             keyboard = _build_counter_keyboard(week_num, cmd, new_count)
+            await self.bot.edit_message_text(
+                text,
+                call.message.chat.id,
+                call.message.message_id,
+                reply_markup=keyboard,
+            )
+            await self.bot.answer_callback_query(call.id, toast)
+
+        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("resetcounter:"))
+        async def handle_reset_counter_callback(call):
+            resolved = await _resolve_subtask_callback(call)
+            if resolved is None:
+                return
+            role, subtask, person, cmd, week_num = resolved
+
+            # Symmetric re-derivation to handle_counter_callback's: don't trust
+            # the "resetcounter:" prefix, in case a stale button from before a
+            # subtask left COUNTER_SUBTASKS is still clickable.
+            if not menage.is_counter_subtask(role, subtask):
+                await self.bot.answer_callback_query(
+                    call.id, "Cette tâche a changé, relance la commande.", show_alert=True,
+                )
+                return
+
+            chores.reset_subtask_counter(role, subtask)
+            toast = f"{subtask} remis à 0."
+
+            assignments = menage.get_role_assignments(colocataires)
+            assigned_person = assignments.get(role, "?")
+            text = _build_counter_text(role, subtask, assigned_person, 0)
+            keyboard = _build_counter_keyboard(week_num, cmd, 0)
             await self.bot.edit_message_text(
                 text,
                 call.message.chat.id,

--- a/tests/test_chores.py
+++ b/tests/test_chores.py
@@ -537,6 +537,25 @@ def test_increment_subtask_counter_reads_back_new_count(mock_get_table, mock_wee
     assert last_call["ExpressionAttributeValues"][":person_set"] == {"Léa"}
 
 
+# --- reset_subtask_counter tests ---
+
+
+@patch("src.chores._current_week_key", return_value="2026-W14")
+@patch("src.chores._get_table")
+def test_reset_subtask_counter_writes_empty_counter(mock_get_table, mock_week):
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    chores.reset_subtask_counter("CUISINE", "plan de travail")
+
+    mock_table.update_item.assert_called_once()
+    call = mock_table.update_item.call_args[1]
+    assert call["Key"] == {"week_key": "2026-W14"}
+    assert call["ExpressionAttributeValues"][":empty_counter"] == {"count": 0}
+    assert call["ExpressionAttributeNames"]["#role"] == "CUISINE"
+    assert call["ExpressionAttributeNames"]["#subtask"] == "plan de travail"
+
+
 # --- is_role_complete / _pending_detail with counter subtasks ---
 
 

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -1431,9 +1431,19 @@ def test_build_subtask_text_done_by_someone_else():
 
 def test_build_counter_keyboard_shows_count_and_callback():
     kb = _build_counter_keyboard(15, "plandetravail", 2)
-    assert len(kb.keyboard) == 1
     assert "2" in kb.keyboard[0][0].text
     assert kb.keyboard[0][0].callback_data == "counter:15:plandetravail"
+
+
+def test_build_counter_keyboard_at_zero_has_no_reset_button():
+    kb = _build_counter_keyboard(15, "plandetravail", 0)
+    assert len(kb.keyboard) == 1
+
+
+def test_build_counter_keyboard_positive_count_adds_reset_button():
+    kb = _build_counter_keyboard(15, "plandetravail", 2)
+    assert len(kb.keyboard) == 2
+    assert kb.keyboard[1][0].callback_data == "resetcounter:15:plandetravail"
 
 
 def test_build_counter_text_zero():
@@ -1932,6 +1942,97 @@ async def test_counter_callback_invalid_subtask_for_role(
     mock_increment.assert_not_called()
     toast = bot.bot.answer_callback_query.call_args[0][1]
     assert "inconnue" in toast.lower()
+
+
+# --- resetcounter: callback ---
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.reset_subtask_counter")
+@patch("src.drahmbot.menage.get_role_assignments", return_value={"CUISINE": "Timon"})
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_reset_counter_callback_anyone_can_reset(
+    mock_group, mock_token, mock_dt, mock_assignments, mock_reset,
+):
+    """Léa can reset /plandetravail's count even though it's shared by everyone."""
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Léa"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "resetcounter:15:plandetravail"
+        call.from_user.id = 42
+        call.id = "cbr1"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_reset.assert_called_once_with("CUISINE", "plan de travail")
+        bot.bot.edit_message_text.assert_called_once()
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "remis à 0" in toast
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.reset_subtask_counter")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_reset_counter_callback_stale_week(mock_group, mock_token, mock_dt, mock_reset):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 16, 1)
+
+    bot = Drahmbot()
+    bot.bot.answer_callback_query = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    call = MagicMock()
+    call.data = "resetcounter:15:plandetravail"
+    call.from_user.id = 891406979
+    call.id = "cbr2"
+
+    await handlers["_callback_query"](call)
+    mock_reset.assert_not_called()
+    toast = bot.bot.answer_callback_query.call_args[0][1]
+    assert "semaine" in toast.lower()
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo"])
+@patch("src.drahmbot.chores.reset_subtask_counter")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_reset_counter_callback_rejects_subtask_no_longer_a_counter(
+    mock_group, mock_token, mock_dt, mock_reset, mock_subtasks,
+):
+    """A "resetcounter:...:frigo" callback must not reset frigo's (non-counter) data."""
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+
+    bot = Drahmbot()
+    bot.bot.answer_callback_query = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    call = MagicMock()
+    call.data = "resetcounter:15:frigo"
+    call.from_user.id = 891406979
+    call.id = "cbr3"
+
+    await handlers["_callback_query"](call)
+    mock_reset.assert_not_called()
+    toast = bot.bot.answer_callback_query.call_args[0][1]
+    assert "changé" in toast.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Lets anyone zero out a counter subtask's count for the week (e.g. plan de travail), clearing all contributors. No confirmation needed: an accidental reset is trivially undone by pressing +1 the same number of times again.