### PR TITLE
feat: add /leaderboard and exhaustive /stats, fold cendrier into /done

### DIFF
--- a/src/cendrier.py
+++ b/src/cendrier.py
@@ -7,10 +7,13 @@ import boto3
 logger = logging.getLogger(__name__)
 
 # Reuses the chores table under a distinct row per week ("cendrier:2026-W14")
-# so it doesn't interfere with chores.get_stats scanning plain chore rows
-# ("2026-W14"). Standalone: unlike CUISINE/SDBs/SOLs/DÉCHETS this task never
-# rotates and isn't part of /recap, /reminder, or /stats.
+# so it doesn't interfere with chores._aggregate_completions scanning plain
+# chore rows ("2026-W14"). Standalone: unlike CUISINE/SDBs/SOLs/DÉCHETS this
+# task never rotates and isn't part of /recap, /reminder, or /leaderboard.
 CENDRIER_KEY_PREFIX = "cendrier:"
+
+# Whoever is on the hook for /cendrier, regardless of chore-role rotation.
+SMOKERS = {"Maël"}
 
 _table = None
 
@@ -28,6 +31,11 @@ def _get_table():
 def _current_week_key() -> str:
     iso = datetime.date.today().isocalendar()
     return f"{CENDRIER_KEY_PREFIX}{iso[0]}-W{iso[1]:02d}"
+
+
+def is_smoker(person: str) -> bool:
+    """Whether this person is on the hook for the standalone cendrier task."""
+    return person in SMOKERS
 
 
 def get_week_state() -> dict:

--- a/src/chores.py
+++ b/src/chores.py
@@ -3,7 +3,10 @@ import logging
 import datetime
 import boto3
 
+from src import menage
 from src import phrases
+from src import plants
+
 
 logger = logging.getLogger(__name__)
 
@@ -181,8 +184,6 @@ def is_subtask_satisfied(sub_data: dict) -> bool:
 
 def is_role_complete(role: str, completed_map: dict) -> bool:
     """Check if a role is fully completed, handling both old and new formats."""
-    from src.menage import get_subtasks_for_role
-
     if role not in completed_map:
         return False
 
@@ -194,7 +195,7 @@ def is_role_complete(role: str, completed_map: dict) -> bool:
 
     # New format: {subtasks: {name: {by, at}, ...}}
     if "subtasks" in role_data:
-        expected = get_subtasks_for_role(role)
+        expected = menage.get_subtasks_for_role(role)
         if expected is None:
             return False
         completed_subtasks = role_data["subtasks"]
@@ -208,9 +209,7 @@ def is_role_complete(role: str, completed_map: dict) -> bool:
 
 def _pending_detail(role: str, completed: dict) -> str:
     """Return detail string for sub-task roles with missing items."""
-    from src.menage import get_subtasks_for_role
-
-    expected = get_subtasks_for_role(role)
+    expected = menage.get_subtasks_for_role(role)
     if expected is None:
         return ""
 
@@ -287,41 +286,186 @@ def get_thursday_reminder(role_assignments: dict) -> str:
     return "\n".join(lines)
 
 
-def get_stats() -> str:
-    """Aggregate chore completions across all weeks and return a formatted leaderboard."""
-    table = _get_table()
-    response = table.scan()
-    items = response.get("Items", [])
+def _bump(counts: dict, key) -> None:
+    counts[key] = counts.get(key, 0) + 1
 
-    counts: dict[str, int] = {}
+
+def _grouped_by_score(totals: dict) -> list:
+    """Group people by score, descending, ties combined into one entry so a
+    medal/rank never implies a false ordering between people who are tied.
+    Returns [(score, [people sorted alphabetically]), ...].
+    """
+    scores = sorted(set(totals.values()), reverse=True)
+    return [(score, sorted(p for p, c in totals.items() if c == score)) for score in scores]
+
+
+def _aggregate_completions() -> dict:
+    """Scan every row once and bucket chore completions by person, role, and
+    (role, subtask), plus a cendrier trivia count. Every subtask completion
+    counts on its own: unlike the older role-only counting still used
+    elsewhere, a role doesn't need to be fully finished for its subtask
+    credits to show up here.
+
+    Old-format {by, at} role entries only contribute to the person/role
+    totals: there's no subtask breakdown to attribute for them.
+    """
+    table = _get_table()
+    items = table.scan().get("Items", [])
+
+    person_totals: dict[str, int] = {}
+    role_totals: dict[str, dict[str, int]] = {}
+    subtask_totals: dict[tuple, dict[str, int]] = {}
+    weeks_tracked = 0
+    cendrier_weeks = 0
+
     for item in items:
-        completed = item.get("completed", {})
+        if "cendrier" in item:
+            cendrier_weeks += 1
+            continue
+        completed = item.get("completed")
+        if completed is None:
+            continue
+        weeks_tracked += 1
         for role, role_data in completed.items():
-            # Old format: {by, at}
             if "by" in role_data:
                 person = role_data["by"]
-                counts[person] = counts.get(person, 0) + 1
-            # New format: {subtasks: {name: {by, at}, ...}}
+                _bump(person_totals, person)
+                _bump(role_totals.setdefault(role, {}), person)
             elif "subtasks" in role_data:
-                if is_role_complete(role, completed):
-                    names = set()
-                    for sub_data in role_data["subtasks"].values():
-                        if "doers" in sub_data:
-                            names.update(sub_data["doers"])
-                        elif "by" in sub_data:
-                            names.add(sub_data["by"])
-                    for person in names:
-                        counts[person] = counts.get(person, 0) + 1
+                for subtask, sub_data in role_data["subtasks"].items():
+                    doers = sub_data.get("doers")
+                    if doers is None:
+                        doers = {sub_data["by"]} if sub_data.get("by") else set()
+                    for person in doers:
+                        _bump(person_totals, person)
+                        _bump(role_totals.setdefault(role, {}), person)
+                        _bump(subtask_totals.setdefault((role, subtask), {}), person)
 
-    if not counts:
+    return {
+        "person_totals": person_totals,
+        "role_totals": role_totals,
+        "subtask_totals": subtask_totals,
+        "weeks_tracked": weeks_tracked,
+        "cendrier_weeks": cendrier_weeks,
+        # Folded into this same scan so get_stats/get_leaderboard don't pay
+        # for a second full table.scan() via plants.get_watering_totals().
+        "plant_totals": plants.compute_watering_totals(items),
+    }
+
+
+def get_stats() -> str:
+    """Exhaustive, dev-chat-only breakdown: every person's total, a per-role
+    and per-subtask breakdown, averages, and the most/least active people.
+    See get_leaderboard() for the positive-only, public equivalent.
+    """
+    agg = _aggregate_completions()
+    person_totals = agg["person_totals"]
+    plant_totals = agg["plant_totals"]
+
+    if not person_totals and not plant_totals and not agg["cendrier_weeks"]:
         return phrases.pick(phrases.STATS_EMPTY)
 
-    medals = ["🥇", "🥈", "🥉"]
-    sorted_people = sorted(counts.items(), key=lambda x: x[1], reverse=True)
     lines = [phrases.pick(phrases.STATS_HEADER)]
-    for i, (person, count) in enumerate(sorted_people):
-        prefix = f"  {medals[i]} " if i < len(medals) else "  "
-        lines.append(f"{prefix}{person} : {count} tâches")
+
+    if person_totals:
+        grouped = _grouped_by_score(person_totals)
+        medals = ["🥇", "🥈", "🥉"]
+        lines.append("")
+        lines.append("🏆 Classement général")
+        for i, (count, people) in enumerate(grouped):
+            prefix = f"  {medals[i]} " if i < len(medals) else "     "
+            lines.append(f"{prefix}{', '.join(people)} : {count} tâches")
+
+        total = sum(person_totals.values())
+        avg = total / len(person_totals)
+        lines.append("")
+        lines.append(
+            f"📈 {agg['weeks_tracked']} semaine(s) suivie(s) · "
+            f"moyenne {avg:.1f} tâches/personne"
+        )
+        top_count, top_people = grouped[0]
+        bottom_count, bottom_people = grouped[-1]
+        lines.append(f"🔥 Plus actif·ve : {', '.join(top_people)}")
+        if bottom_count != top_count:
+            lines.append(f"🥶 Moins actif·ve : {', '.join(bottom_people)}")
+
+    for role in menage.ROLES:
+        role_counts = agg["role_totals"].get(role)
+        if not role_counts:
+            continue
+        lines.append("")
+        lines.append(f"{menage.ROLE_EMOJIS.get(role, '')} {role}")
+        for person, count in sorted(role_counts.items(), key=lambda x: x[1], reverse=True):
+            lines.append(f"  {person} : {count}")
+
+    if agg["subtask_totals"]:
+        lines.append("")
+        lines.append("🔍 Détail par tâche")
+        sorted_subtasks = sorted(
+            agg["subtask_totals"].items(), key=lambda x: (x[0][0], x[0][1].lower())
+        )
+        for (role, subtask), counts in sorted_subtasks:
+            label = subtask
+            if menage.is_counter_subtask(role, subtask):
+                label = f"{subtask} (participations, pas le nombre de fois)"
+            parts = ", ".join(
+                f"{person} {count}"
+                for person, count in sorted(counts.items(), key=lambda x: x[1], reverse=True)
+            )
+            lines.append(f"  {label} : {parts}")
+
+    if plant_totals:
+        lines.append("")
+        lines.append("🌱 Arrosage des plantes")
+        for person, count in sorted(plant_totals.items(), key=lambda x: x[1], reverse=True):
+            lines.append(f"  {person} : {count}")
+
+    if agg["cendrier_weeks"]:
+        lines.append("")
+        lines.append(f"🚬 Cendrier sorti {agg['cendrier_weeks']} fois (toujours par Maël)")
+
+    return "\n".join(lines)
+
+
+def get_leaderboard() -> str:
+    """Positive-only, all-time highlights for everyone to see: the top
+    scorer(s), a champion per role, and the plant-watering MVP. No bottom
+    rankings: see get_stats() for the exhaustive, dev-chat-only breakdown.
+    """
+    agg = _aggregate_completions()
+    person_totals = agg["person_totals"]
+    plant_totals = agg["plant_totals"]
+
+    if not person_totals and not plant_totals:
+        return phrases.pick(phrases.LEADERBOARD_EMPTY)
+
+    lines = [phrases.pick(phrases.LEADERBOARD_HEADER)]
+
+    if person_totals:
+        grouped = _grouped_by_score(person_totals)[:3]
+        medals = ["🥇", "🥈", "🥉"]
+        lines.append("")
+        lines.append("🏆 Classement général")
+        for i, (count, people) in enumerate(grouped):
+            lines.append(f"  {medals[i]} {', '.join(people)} : {count} tâches")
+
+    if agg["role_totals"]:
+        lines.append("")
+        for role in menage.ROLES:
+            role_counts = agg["role_totals"].get(role)
+            if not role_counts:
+                continue
+            top_count, champions = _grouped_by_score(role_counts)[0]
+            lines.append(
+                f"{menage.ROLE_EMOJIS.get(role, '')} {role} : {', '.join(champions)} "
+                f"({top_count} fois)"
+            )
+
+    if plant_totals:
+        top_count, friends = _grouped_by_score(plant_totals)[0]
+        lines.append("")
+        lines.append(f"🌱 Best Plant Friend : {', '.join(friends)} ({top_count} arrosages)")
+
     return "\n".join(lines)
 
 

--- a/src/drahmbot.py
+++ b/src/drahmbot.py
@@ -53,12 +53,21 @@ class ColocAccessMiddleware(BaseMiddleware):
         pass
 
 
-def _build_done_keyboard(role, week_num):
-    """Build an InlineKeyboardMarkup for a role's done status."""
+def _build_done_keyboard(role, week_num, person, completed=None, cendrier_state=None):
+    """Build an InlineKeyboardMarkup for a role's done status, plus a
+    cendrier row for smokers (it isn't part of role rotation, see
+    CLAUDE.md, so it wouldn't otherwise show up here).
+
+    `completed`/`cendrier_state` let a caller that already has fresh data
+    (e.g. right after a toggle) pass it in instead of this function
+    re-fetching it, avoiding both a redundant DynamoDB read and, for
+    cendrier, a stale eventually-consistent read right after a write.
+    """
     subtasks = menage.get_subtasks_for_role(role)
     keyboard = telebot.types.InlineKeyboardMarkup()
 
-    completed = chores.get_week_status()
+    if completed is None:
+        completed = chores.get_week_status()
     role_data = completed.get(role, {})
 
     if subtasks is None:
@@ -88,20 +97,33 @@ def _build_done_keyboard(role, week_num):
             )
             keyboard.add(button)
 
+    if cendrier.is_smoker(person):
+        if cendrier_state is None:
+            cendrier_state = cendrier.get_week_state()
+        icon = "\u2705" if cendrier_state else "\u2b1c"
+        keyboard.add(telebot.types.InlineKeyboardButton(
+            text=f"{icon} Cendrier",
+            callback_data=f"donecendrier:{week_num}:{role}",
+        ))
+
     return keyboard
 
 
-def _build_done_text(role, person):
-    """Build status text for a role's done message."""
+def _build_done_text(role, person, completed=None, cendrier_state=None):
+    """Build status text for a role's done message, plus a cendrier line
+    for smokers. See _build_done_keyboard for why completed/cendrier_state
+    can be passed in instead of re-fetched."""
     subtasks = menage.get_subtasks_for_role(role)
-    completed = chores.get_week_status()
+    if completed is None:
+        completed = chores.get_week_status()
     role_data = completed.get(role, {})
 
     if subtasks is None:
         is_done = "by" in role_data
         if is_done:
-            return f"{person} \u2014 {role} : fait \u2705"
-        return f"{person} \u2014 {role} : clique pour marquer comme fait."
+            text = f"{person} \u2014 {role} : fait \u2705"
+        else:
+            text = f"{person} \u2014 {role} : clique pour marquer comme fait."
     else:
         completed_subtasks = role_data.get("subtasks", {})
         done_count = sum(
@@ -110,8 +132,16 @@ def _build_done_text(role, person):
         )
         total = len(subtasks)
         if done_count == total:
-            return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites \u2705"
-        return f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites."
+            text = f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites \u2705"
+        else:
+            text = f"{person} \u2014 {role} : {done_count}/{total} sous-t\u00e2ches faites."
+
+    if cendrier.is_smoker(person):
+        if cendrier_state is None:
+            cendrier_state = cendrier.get_week_state()
+        text += "\n\n" + _build_cendrier_text(cendrier_state)
+
+    return text
 
 
 def _build_plants_keyboard(date_iso, watered):
@@ -350,8 +380,10 @@ class Drahmbot:
                 return
 
             week_num = datetime.date.today().isocalendar()[1]
-            keyboard = _build_done_keyboard(role, week_num)
-            text = _build_done_text(role, person)
+            completed = chores.get_week_status()
+            cendrier_state = cendrier.get_week_state() if cendrier.is_smoker(person) else None
+            keyboard = _build_done_keyboard(role, week_num, person, completed, cendrier_state)
+            text = _build_done_text(role, person, completed, cendrier_state)
             await self.bot.send_message(message.chat.id, text, reply_markup=keyboard)
 
         @self.bot.callback_query_handler(func=lambda call: call.data.startswith("done:"))
@@ -404,8 +436,10 @@ class Drahmbot:
                 now_done = chores.toggle_role(role, person)
                 toast = f"{role} fait !" if now_done else f"{role} annulé."
 
-            keyboard = _build_done_keyboard(role, week_num)
-            text = _build_done_text(role, person)
+            completed = chores.get_week_status()
+            cendrier_state = cendrier.get_week_state() if cendrier.is_smoker(person) else None
+            keyboard = _build_done_keyboard(role, week_num, person, completed, cendrier_state)
+            text = _build_done_text(role, person, completed, cendrier_state)
             await self.bot.edit_message_text(
                 text,
                 call.message.chat.id,
@@ -426,6 +460,13 @@ class Drahmbot:
             logger.info("Command /recap received from %s", message.chat.id)
             assignments = menage.get_role_assignments(colocataires)
             answer = chores.get_sunday_recap(assignments)
+            await self.bot.send_message(message.chat.id, answer)
+            await self.bot.send_message(message.chat.id, chores.get_leaderboard())
+
+        @self.bot.message_handler(commands=['leaderboard'])
+        async def send_leaderboard(message):
+            logger.info("Command /leaderboard received from %s", message.chat.id)
+            answer = chores.get_leaderboard()
             await self.bot.send_message(message.chat.id, answer)
 
         @self.bot.message_handler(commands=['arrosage'])
@@ -772,25 +813,24 @@ class Drahmbot:
             keyboard = _build_cendrier_keyboard(week_num, bool(state))
             await self.bot.send_message(message.chat.id, text, reply_markup=keyboard)
 
-        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("cendrier:"))
-        async def handle_cendrier_callback(call):
-            parts = call.data.split(":")
-            if len(parts) != 2:
-                await self.bot.answer_callback_query(call.id, "Données invalides.")
-                return
+        async def _resolve_and_toggle_cendrier(call, week_num):
+            """Shared week-check/person-resolution/permission-check/toggle
+            for the standalone cendrier: button and the /done-embedded
+            donecendrier: row. Anyone can mark it done (same open-help model
+            as any other subtask), but only the doer can undo it. Each
+            caller parses its own callback_data shape and passes in the
+            already-extracted week_num, since cendrier: and donecendrier:
+            carry different payloads (donecendrier: also embeds a role).
 
-            try:
-                week_num = int(parts[1])
-            except ValueError:
-                await self.bot.answer_callback_query(call.id, "Données invalides.")
-                return
-
+            Returns (person, new_state, toast), or None after already
+            answering the callback query with an error.
+            """
             current_week = datetime.date.today().isocalendar()[1]
             if week_num != current_week:
                 await self.bot.answer_callback_query(
                     call.id, "Trop tard, c'est une autre semaine.", show_alert=True,
                 )
-                return
+                return None
 
             user_id = call.from_user.id
             person = TELEGRAM_USER_MAP.get(user_id)
@@ -798,7 +838,7 @@ class Drahmbot:
                 await self.bot.answer_callback_query(
                     call.id, "Tu n'es pas reconnu.", show_alert=True,
                 )
-                return
+                return None
 
             existing = cendrier.get_week_state()
             # Only the doer may untoggle. Open click to mark; restricted undo.
@@ -808,13 +848,72 @@ class Drahmbot:
                     f"Seul·e {existing['by']} peut annuler.",
                     show_alert=True,
                 )
-                return
+                return None
 
             new_state = cendrier.toggle_week_state(person)
             toast = "Cendrier vidé !" if new_state else "Annulé."
+            return person, new_state, toast
+
+        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("cendrier:"))
+        async def handle_cendrier_callback(call):
+            parts = call.data.split(":")
+            if len(parts) != 2:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+            try:
+                week_num = int(parts[1])
+            except ValueError:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+
+            resolved = await _resolve_and_toggle_cendrier(call, week_num)
+            if resolved is None:
+                return
+            _person, new_state, toast = resolved
 
             text = _build_cendrier_text(new_state)
             keyboard = _build_cendrier_keyboard(week_num, bool(new_state))
+            await self.bot.edit_message_text(
+                text,
+                call.message.chat.id,
+                call.message.message_id,
+                reply_markup=keyboard,
+            )
+            await self.bot.answer_callback_query(call.id, toast)
+
+        @self.bot.callback_query_handler(func=lambda call: call.data.startswith("donecendrier:"))
+        async def handle_done_cendrier_callback(call):
+            """Cendrier row embedded in /done's keyboard (see
+            _build_done_keyboard): toggles the same cendrier state as the
+            standalone /cendrier button (anyone can help), but always
+            re-renders the combined role+cendrier view for the message's
+            original owner (the role embedded in callback_data), not
+            whoever tapped the button, since /done messages are posted to
+            the shared group chat and visible/tappable by everyone."""
+            parts = call.data.split(":")
+            if len(parts) != 3:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+            try:
+                week_num = int(parts[1])
+            except ValueError:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+            role = parts[2]
+
+            owner = menage.get_role_assignments(colocataires).get(role)
+            if owner is None:
+                await self.bot.answer_callback_query(call.id, "Données invalides.")
+                return
+
+            resolved = await _resolve_and_toggle_cendrier(call, week_num)
+            if resolved is None:
+                return
+            _person, new_state, toast = resolved
+
+            completed = chores.get_week_status()
+            keyboard = _build_done_keyboard(role, week_num, owner, completed, new_state)
+            text = _build_done_text(role, owner, completed, new_state)
             await self.bot.edit_message_text(
                 text,
                 call.message.chat.id,

--- a/src/menage.py
+++ b/src/menage.py
@@ -9,6 +9,13 @@ logger = logging.getLogger(__name__)
 
 ROLES = ["CUISINE", "SDBs", "SOLs", "DÉCHETS"]
 
+ROLE_EMOJIS = {
+    "CUISINE": "\U0001F373",
+    "SDBs": "\U0001F6BF",
+    "SOLs": "\U0001F9F9",
+    "DÉCHETS": "\U0001F5D1️",
+}
+
 # Chance that roles don't rotate this week — pure chaos/joke
 CHAOS_KEEP_ROLES_PROBABILITY = 0.05
 
@@ -113,15 +120,15 @@ def getRoles(colocataires: list):
 
     body = """
         ROLES DU MENAGES ATTRIBUÉS ALEATOIREMENT PAR LE DRAHMBOT    :
-        - \U0001F373 CUISINE    : {}
-        - \U0001F6BF SDBs       : {}
-        - \U0001F9F9 SOLs       : {}
-        - \U0001F5D1\uFE0F DÉCHETs     : {}
+        - {cuisine_emoji} CUISINE    : {cuisine}
+        - {sdbs_emoji} SDBs       : {sdbs}
+        - {sols_emoji} SOLs       : {sols}
+        - {dechets_emoji} DÉCHETs     : {dechets}
     """.format(
-        assignments["CUISINE"],
-        assignments["SDBs"],
-        assignments["SOLs"],
-        assignments["DÉCHETS"],
+        cuisine_emoji=ROLE_EMOJIS["CUISINE"], cuisine=assignments["CUISINE"],
+        sdbs_emoji=ROLE_EMOJIS["SDBs"], sdbs=assignments["SDBs"],
+        sols_emoji=ROLE_EMOJIS["SOLs"], sols=assignments["SOLs"],
+        dechets_emoji=ROLE_EMOJIS["DÉCHETS"], dechets=assignments["DÉCHETS"],
     )
 
     if _should_keep_same_roles():

--- a/src/phrases.py
+++ b/src/phrases.py
@@ -116,6 +116,22 @@ STATS_EMPTY = [
     "C'est le désert niveau stats, bougez-vous ehehe",
 ]
 
+LEADERBOARD_HEADER = [
+    "🏆 Palmarès de la coloc :",
+    "Le classement des champions :",
+    "Qui claque le plus la coloc :",
+    "Le mur de la gloire :",
+    "Highlights de la coloc :",
+    "Petit hommage aux champions de la coloc :",
+]
+
+LEADERBOARD_EMPTY = [
+    "Pas encore de champion, personne n'a rien fait !",
+    "Le podium est vide, à vous de jouer",
+    "Aucun exploit à célébrer pour l'instant",
+    "Le mur de la gloire est encore vide ehehe",
+]
+
 ARROSAGE_HEADER = [
     "🌡️ {temp}°C aujourd'hui à Zürich. Les plantes vous regardent.",
     "Yo, il va faire {temp}°C aujourd'hui. Pensez aux plantes.",

--- a/src/plants.py
+++ b/src/plants.py
@@ -15,7 +15,8 @@ _WATERED_STATES = frozenset({STATE_WATERED, _LEGACY_WATERED_STATE})
 
 # Reuses the chores table. The key field is named `week_key` but DynamoDB
 # treats it as an opaque string. Prefix `plant:` keeps these rows distinct
-# from chore rows (`2026-W14`) so `chores.get_stats` ignores them naturally.
+# from chore rows (`2026-W14`) so `chores._aggregate_completions` ignores
+# them naturally when bucketing chore completions.
 PLANT_KEY_PREFIX = "plant:"
 
 _table = None
@@ -67,6 +68,31 @@ def get_last_watered_date(lookback_days: int = 5):
         if is_watered(watering):
             return date
     return None
+
+
+def compute_watering_totals(items) -> dict:
+    """Count watered days per person from already-fetched table items.
+
+    Lets a caller that already ran its own table.scan() over the shared
+    table (e.g. chores._aggregate_completions) fold in plant totals without
+    paying for a second full scan.
+    """
+    totals: dict[str, int] = {}
+    for item in items:
+        if not item.get("week_key", "").startswith(PLANT_KEY_PREFIX):
+            continue
+        watering = item.get("watering", {})
+        person = watering.get("by")
+        if person and is_watered(watering):
+            totals[person] = totals.get(person, 0) + 1
+    return totals
+
+
+def get_watering_totals() -> dict:
+    """All-time count of watered days per person, across every day ever recorded."""
+    table = _get_table()
+    items = table.scan().get("Items", [])
+    return compute_watering_totals(items)
 
 
 def toggle_today_state(person: str) -> dict:

--- a/tests/test_chores.py
+++ b/tests/test_chores.py
@@ -158,8 +158,8 @@ def test_get_stats_multiple_weeks(mock_get_table):
     # Timon should be first (gold medal)
     assert "🥇" in result
     lines = result.split("\n")
-    # First person line (index 1) should be Timon
-    assert "Timon" in lines[1]
+    medal_line = next(l for l in lines if "🥇" in l)
+    assert "Timon" in medal_line
 
 
 @patch("src.chores._get_table")
@@ -482,12 +482,11 @@ def test_get_stats_with_subtask_format(mock_get_table, mock_even):
     mock_get_table.return_value = mock_table
 
     result = chores.get_stats()
-    # Timon: 1 (CUISINE old format)
-    assert "Timon : 1 tâches" in result
-    # Léa: 1 (SOLs fully complete)
-    assert "Léa : 1 tâches" in result
-    # Alexis: 0 (DÉCHETS not fully complete — only 1 of 5 subtasks)
-    assert "Alexis" not in result
+    # Léa: 2 (SOLs: aspirateur + panosse, each subtask counts on its own)
+    assert "Léa : 2 tâches" in result
+    # Timon: 1 (CUISINE old format), Alexis: 1 (DÉCHETS poubelle) - tied, so
+    # they're grouped on one line rather than each getting their own rank.
+    assert "Alexis, Timon : 1 tâches" in result
 
 
 # --- increment_subtask_counter tests ---
@@ -702,11 +701,13 @@ def test_get_stats_counter_credits_every_doer_not_just_last(mock_get_table, mock
     mock_get_table.return_value = mock_table
 
     result = chores.get_stats()
-    assert "Timon : 1 tâches" in result
+    # Timon: frigo + plan de travail + rangement + balcon = 4
+    assert "Timon : 4 tâches" in result
+    # Léa: credited once for pitching in on the counter subtask
     assert "Léa : 1 tâches" in result
 
 
-# --- stats: counter subtask only ever contributes once per week ---
+# --- stats: counter subtask only ever contributes once per week per doer ---
 
 
 @patch("src.chores._get_table")
@@ -730,5 +731,147 @@ def test_get_stats_counter_subtask_counts_once_regardless_of_count_value(mock_ge
     mock_get_table.return_value = mock_table
 
     result = chores.get_stats()
-    # Timon gets 1 point for the complete CUISINE role, not 5 for the counter.
-    assert "Timon : 1 tâches" in result
+    # Timon gets 1 point per subtask, not 5 for the counter's raw count.
+    assert "Timon : 4 tâches" in result
+    assert "plan de travail (participations, pas le nombre de fois) : Timon 1" in result
+
+
+# --- _aggregate_completions ---
+
+
+@patch("src.menage.is_even_week", return_value=False)
+@patch("src.chores._get_table")
+def test_aggregate_completions_mixed_formats(mock_get_table, mock_even):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {
+                "week_key": "2026-W10",
+                "completed": {"CUISINE": {"by": "Timon", "at": "..."}},
+            },
+            {
+                "week_key": "2026-W11",
+                "completed": {
+                    "SOLs": {"subtasks": {
+                        "aspirateur": {"by": "Léa", "at": "..."},
+                        "panosse": {
+                            "by": "Léa", "at": "...", "doers": {"Léa", "Maël"},
+                        },
+                    }},
+                },
+            },
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    agg = chores._aggregate_completions()
+    assert agg["weeks_tracked"] == 2
+    assert agg["cendrier_weeks"] == 0
+    assert agg["person_totals"] == {"Timon": 1, "Léa": 2, "Maël": 1}
+    assert agg["role_totals"] == {"CUISINE": {"Timon": 1}, "SOLs": {"Léa": 2, "Maël": 1}}
+    assert agg["subtask_totals"] == {
+        ("SOLs", "aspirateur"): {"Léa": 1},
+        ("SOLs", "panosse"): {"Léa": 1, "Maël": 1},
+    }
+
+
+@patch("src.chores._get_table")
+def test_aggregate_completions_counts_cendrier_and_ignores_plant_rows(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {"week_key": "cendrier:2026-W10", "cendrier": {"by": "Maël", "at": "..."}},
+            {"week_key": "plant:2026-05-01", "watering": {"state": "watered", "by": "Alexis"}},
+            {"week_key": "2026-W10"},  # a week row with nothing done yet
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    agg = chores._aggregate_completions()
+    assert agg["cendrier_weeks"] == 1
+    assert agg["weeks_tracked"] == 0
+    assert agg["person_totals"] == {}
+
+
+# --- get_leaderboard ---
+
+
+@patch("src.chores._get_table")
+def test_get_leaderboard_empty(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {"Items": []}
+    mock_get_table.return_value = mock_table
+
+    from src.phrases import LEADERBOARD_EMPTY
+    result = chores.get_leaderboard()
+    assert result in LEADERBOARD_EMPTY
+
+
+@patch("src.chores._get_table")
+def test_get_leaderboard_top3_medals_and_role_champion(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {
+                "week_key": "2026-W10",
+                "completed": {
+                    "CUISINE": {"by": "Timon", "at": "..."},
+                    "SDBs": {"by": "Maël", "at": "..."},
+                },
+            },
+            {
+                "week_key": "2026-W11",
+                "completed": {"CUISINE": {"by": "Timon", "at": "..."}},
+            },
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    from src.phrases import LEADERBOARD_HEADER
+    result = chores.get_leaderboard()
+    assert any(h in result for h in LEADERBOARD_HEADER)
+    assert "🥇 Timon : 2 tâches" in result
+    assert "🥈 Maël : 1 tâches" in result
+    assert "CUISINE : Timon (2 fois)" in result
+    assert "SDBs : Maël (1 fois)" in result
+    # No bottom-ranking / least-active line: this view is positive-only.
+    assert "actif" not in result
+
+
+@patch("src.chores._get_table")
+def test_get_leaderboard_ties_shown_together(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {
+                "week_key": "2026-W10",
+                "completed": {"CUISINE": {"by": "Timon", "at": "..."}},
+            },
+            {
+                "week_key": "2026-W11",
+                "completed": {"CUISINE": {"by": "Léa", "at": "..."}},
+            },
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    result = chores.get_leaderboard()
+    assert "CUISINE : Léa, Timon (1 fois)" in result
+
+
+@patch("src.chores._get_table")
+def test_get_leaderboard_includes_best_plant_friend(mock_get_table):
+    """Plant totals now come from the same table.scan() chores.py already
+    does (via plants.compute_watering_totals), not a second scan."""
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {"week_key": "plant:2026-05-01", "watering": {"state": "watered", "by": "Alexis"}},
+            {"week_key": "plant:2026-05-02", "watering": {"state": "watered", "by": "Alexis"}},
+            {"week_key": "plant:2026-05-03", "watering": {"state": "watered", "by": "Léa"}},
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    result = chores.get_leaderboard()
+    assert "🌱 Best Plant Friend : Alexis (2 arrosages)" in result

--- a/tests/test_drahmbot.py
+++ b/tests/test_drahmbot.py
@@ -235,6 +235,83 @@ async def test_done_handler_subtask_role(
 
 
 @pytest.mark.asyncio
+@patch("src.drahmbot.cendrier.get_week_state", return_value={})
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+@patch("src.drahmbot.menage.get_role_for_person", return_value="CUISINE")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_done_handler_mael_gets_cendrier_in_same_message(
+    mock_group, mock_token, mock_dt, mock_role, mock_subtasks, mock_status, mock_cendrier_state,
+):
+    """Cendrier is standalone (never part of role rotation), but /done still
+    folds it into Maël's single message rather than a second one."""
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Maël"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.send_message = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        message = MagicMock()
+        message.chat.id = 999
+        message.from_user.id = 42
+
+        await handlers["done"](message)
+        assert bot.bot.send_message.call_count == 1
+        call_args = bot.bot.send_message.call_args
+        assert "Cendrier" in call_args[0][1]
+        keyboard = call_args[1]["reply_markup"]
+        assert keyboard.keyboard[-1][0].callback_data == "donecendrier:15:CUISINE"
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+@patch("src.drahmbot.menage.get_role_for_person", return_value="CUISINE")
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_done_handler_non_smoker_no_cendrier(
+    mock_group, mock_token, mock_dt, mock_role, mock_subtasks, mock_status,
+):
+    """Only smokers (currently just Maël) get the extra cendrier row/line."""
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"
+
+    try:
+        bot = Drahmbot()
+        bot.bot.send_message = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        message = MagicMock()
+        message.chat.id = 999
+        message.from_user.id = 42
+
+        await handlers["done"](message)
+        assert bot.bot.send_message.call_count == 1
+        call_args = bot.bot.send_message.call_args
+        assert "Cendrier" not in call_args[0][1]
+        keyboard = call_args[1]["reply_markup"]
+        assert not any(
+            btn.callback_data.startswith("donecendrier:")
+            for row in keyboard.keyboard for btn in row
+        )
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
 @patch("src.drahmbot.chores.get_thursday_reminder", return_value="Rappel du jeudi : tout ok")
 @patch("src.drahmbot.menage.get_role_assignments", return_value={"CUISINE": "Timon"})
 @patch("src.drahmbot.utils.get_token", return_value="12345:12345")
@@ -252,11 +329,13 @@ async def test_reminder_handler(mock_group, mock_token, mock_assignments, mock_r
 
 
 @pytest.mark.asyncio
+@patch("src.drahmbot.chores.get_leaderboard", return_value="Palmarès de la coloc")
 @patch("src.drahmbot.chores.get_sunday_recap", return_value="Récap de la semaine")
 @patch("src.drahmbot.menage.get_role_assignments", return_value={"CUISINE": "Timon"})
 @patch("src.drahmbot.utils.get_token", return_value="12345:12345")
 @patch("src.drahmbot.utils.get_group_id", return_value=123)
-async def test_recap_handler(mock_group, mock_token, mock_assignments, mock_recap):
+async def test_recap_handler(mock_group, mock_token, mock_assignments, mock_recap, mock_leaderboard):
+    """/recap also sends the all-time leaderboard as a second message."""
     bot = Drahmbot()
     bot.bot.send_message = AsyncMock()
     handlers = _capture_handlers(bot)
@@ -265,7 +344,28 @@ async def test_recap_handler(mock_group, mock_token, mock_assignments, mock_reca
     message.chat.id = 999
 
     await handlers["recap"](message)
-    bot.bot.send_message.assert_called_with(999, "Récap de la semaine")
+    assert bot.bot.send_message.call_args_list == [
+        ((999, "Récap de la semaine"),),
+        ((999, "Palmarès de la coloc"),),
+    ]
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.chores.get_leaderboard", return_value="Palmarès de la coloc")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_leaderboard_handler_any_chat(mock_group, mock_token, mock_leaderboard):
+    """/leaderboard is public: unlike /stats it's not gated to the dev chat."""
+    bot = Drahmbot()
+    bot.dev_chat_id = "-4867763410"
+    bot.bot.send_message = AsyncMock()
+    handlers = _capture_handlers(bot)
+
+    message = MagicMock()
+    message.chat.id = -9999999999  # not the dev chat
+
+    await handlers["leaderboard"](message)
+    bot.bot.send_message.assert_called_once_with(-9999999999, "Palmarès de la coloc")
 
 
 @pytest.mark.asyncio
@@ -411,7 +511,7 @@ async def test_middleware_blocks_unknown_user_callback():
 @patch("src.drahmbot.chores.get_week_status", return_value={})
 @patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
 def test_build_done_keyboard_cuisine_not_done(mock_subtasks, mock_status):
-    keyboard = _build_done_keyboard("CUISINE", 15)
+    keyboard = _build_done_keyboard("CUISINE", 15, "Timon")
     assert len(keyboard.keyboard) == 3
     assert "frigo" in keyboard.keyboard[0][0].text
     assert "plan de travail" in keyboard.keyboard[1][0].text
@@ -429,7 +529,7 @@ def test_build_done_keyboard_cuisine_not_done(mock_subtasks, mock_status):
 })
 @patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
 def test_build_done_keyboard_cuisine_done(mock_subtasks, mock_status):
-    keyboard = _build_done_keyboard("CUISINE", 15)
+    keyboard = _build_done_keyboard("CUISINE", 15, "Timon")
     assert len(keyboard.keyboard) == 3
     assert "\u2705" in keyboard.keyboard[0][0].text
 
@@ -437,7 +537,7 @@ def test_build_done_keyboard_cuisine_done(mock_subtasks, mock_status):
 @patch("src.drahmbot.chores.get_week_status", return_value={})
 @patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["aspirateur", "panosse"])
 def test_build_done_keyboard_subtask_role(mock_subtasks, mock_status):
-    keyboard = _build_done_keyboard("SOLs", 15)
+    keyboard = _build_done_keyboard("SOLs", 15, "Léa")
     assert len(keyboard.keyboard) == 2
     assert "aspirateur" in keyboard.keyboard[0][0].text
     assert "panosse" in keyboard.keyboard[1][0].text
@@ -447,7 +547,7 @@ def test_build_done_keyboard_subtask_role(mock_subtasks, mock_status):
 @patch("src.drahmbot.chores.get_week_status", return_value={})
 @patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail"])
 def test_build_done_keyboard_counter_subtask_shows_count_zero(mock_subtasks, mock_status):
-    keyboard = _build_done_keyboard("CUISINE", 15)
+    keyboard = _build_done_keyboard("CUISINE", 15, "Timon")
     assert "plan de travail" in keyboard.keyboard[1][0].text
     assert "(0x)" in keyboard.keyboard[1][0].text
     assert "⬜" in keyboard.keyboard[1][0].text
@@ -460,9 +560,41 @@ def test_build_done_keyboard_counter_subtask_shows_count_zero(mock_subtasks, moc
 })
 @patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail"])
 def test_build_done_keyboard_counter_subtask_shows_positive_count(mock_subtasks, mock_status):
-    keyboard = _build_done_keyboard("CUISINE", 15)
+    keyboard = _build_done_keyboard("CUISINE", 15, "Timon")
     assert "(3x)" in keyboard.keyboard[1][0].text
     assert "✅" in keyboard.keyboard[1][0].text
+
+
+@patch("src.drahmbot.cendrier.get_week_state", return_value={})
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+def test_build_done_keyboard_smoker_gets_cendrier_row(mock_subtasks, mock_status, mock_cendrier_state):
+    keyboard = _build_done_keyboard("CUISINE", 15, "Maël")
+    assert len(keyboard.keyboard) == 4  # 3 subtasks + cendrier
+    assert keyboard.keyboard[3][0].callback_data == "donecendrier:15:CUISINE"
+    assert "Cendrier" in keyboard.keyboard[3][0].text
+    assert "⬜" in keyboard.keyboard[3][0].text
+
+
+@patch("src.drahmbot.cendrier.get_week_state", return_value={"by": "Maël", "at": "..."})
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+def test_build_done_keyboard_smoker_cendrier_row_reflects_done(
+    mock_subtasks, mock_status, mock_cendrier_state,
+):
+    keyboard = _build_done_keyboard("CUISINE", 15, "Maël")
+    assert "✅" in keyboard.keyboard[3][0].text
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+def test_build_done_keyboard_non_smoker_has_no_cendrier_row(mock_subtasks, mock_status):
+    keyboard = _build_done_keyboard("CUISINE", 15, "Timon")
+    assert len(keyboard.keyboard) == 3
+    assert not any(
+        btn.callback_data.startswith("donecendrier:")
+        for row in keyboard.keyboard for btn in row
+    )
 
 
 @patch("src.drahmbot.chores.get_week_status", return_value={})
@@ -495,6 +627,22 @@ def test_build_done_text_cuisine_done(mock_subtasks, mock_status):
 def test_build_done_text_subtask_partial(mock_subtasks, mock_status):
     text = _build_done_text("SOLs", "Léa")
     assert "1/2" in text
+
+
+@patch("src.drahmbot.cendrier.get_week_state", return_value={})
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+def test_build_done_text_smoker_appends_cendrier_line(mock_subtasks, mock_status, mock_cendrier_state):
+    text = _build_done_text("CUISINE", "Maël")
+    assert "0/3" in text
+    assert "Cendrier" in text
+
+
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+def test_build_done_text_non_smoker_has_no_cendrier_line(mock_subtasks, mock_status):
+    text = _build_done_text("CUISINE", "Timon")
+    assert "Cendrier" not in text
 
 
 # --- Callback handler tests ---
@@ -2325,3 +2473,96 @@ async def test_cendrier_callback_non_numeric_week(mock_group, mock_token, mock_d
     mock_toggle.assert_not_called()
     toast = bot.bot.answer_callback_query.call_args[0][1]
     assert "invalides" in toast.lower()
+
+
+# --- /done-embedded cendrier callback ---
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.cendrier.toggle_week_state",
+       return_value={"by": "Timon", "at": "..."})
+@patch("src.drahmbot.cendrier.get_week_state", return_value={})
+@patch("src.drahmbot.chores.get_week_status", return_value={})
+@patch("src.drahmbot.menage.get_subtasks_for_role", return_value=["frigo", "plan de travail", "rangement"])
+@patch("src.drahmbot.menage.get_role_assignments", return_value={"CUISINE": "Maël"})
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_done_cendrier_callback_rerenders_original_owners_card(
+    mock_group, mock_token, mock_dt, mock_assignments, mock_subtasks, mock_status,
+    mock_state, mock_toggle,
+):
+    """Clicking the cendrier row inside someone else's /done message still
+    toggles cendrier (anyone can help) but must redraw the ORIGINAL card
+    owner's combined view (Maël's), not the clicker's own (Timon's) - the
+    row's callback_data embeds the card's role precisely to prevent this."""
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"  # the clicker, not the card owner
+
+    try:
+        bot = Drahmbot()
+        bot.bot.edit_message_text = AsyncMock()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "donecendrier:15:CUISINE"
+        call.from_user.id = 42
+        call.id = "cbc7"
+        call.message.chat.id = 999
+        call.message.message_id = 100
+
+        await handlers["_callback_query"](call)
+        mock_toggle.assert_called_once_with("Timon")
+        bot.bot.edit_message_text.assert_called_once()
+        edited_text = bot.bot.edit_message_text.call_args[0][0]
+        assert "Maël — CUISINE" in edited_text
+        assert "Timon — CUISINE" not in edited_text
+        # Timon is still rightfully credited as the one who emptied it.
+        assert "vidé par Timon" in edited_text
+        keyboard = bot.bot.edit_message_text.call_args[1]["reply_markup"]
+        assert any(
+            btn.callback_data == "donecendrier:15:CUISINE"
+            for row in keyboard.keyboard for btn in row
+        )
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "vidé" in toast.lower()
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)
+
+
+@pytest.mark.asyncio
+@patch("src.drahmbot.cendrier.toggle_week_state")
+@patch("src.drahmbot.cendrier.get_week_state", return_value={"by": "Maël", "at": "..."})
+@patch("src.drahmbot.menage.get_role_assignments", return_value={"CUISINE": "Maël"})
+@patch("src.drahmbot.datetime")
+@patch("src.drahmbot.utils.get_token", return_value="12345:12345")
+@patch("src.drahmbot.utils.get_group_id", return_value=123)
+async def test_done_cendrier_callback_non_doer_cannot_undo(
+    mock_group, mock_token, mock_dt, mock_assignments, mock_state, mock_toggle,
+):
+    mock_dt.date.today.return_value.isocalendar.return_value = (2026, 15, 1)
+    import src.drahmbot as drahmbot_module
+    original_map = drahmbot_module.TELEGRAM_USER_MAP.copy()
+    drahmbot_module.TELEGRAM_USER_MAP[42] = "Timon"  # not Maël, who did it
+
+    try:
+        bot = Drahmbot()
+        bot.bot.answer_callback_query = AsyncMock()
+        handlers = _capture_handlers(bot)
+
+        call = MagicMock()
+        call.data = "donecendrier:15:CUISINE"
+        call.from_user.id = 42
+        call.id = "cbc8"
+
+        await handlers["_callback_query"](call)
+        mock_toggle.assert_not_called()
+        toast = bot.bot.answer_callback_query.call_args[0][1]
+        assert "Maël" in toast
+    finally:
+        drahmbot_module.TELEGRAM_USER_MAP.clear()
+        drahmbot_module.TELEGRAM_USER_MAP.update(original_map)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -165,9 +165,9 @@ async def test_frigo_write_path_round_trip(bot):
     role_data = chores.get_week_status().get("CUISINE", {})
     assert role_data["subtasks"]["frigo"]["by"] == helper
 
-    # 4. /recap credits the helper, not the assigned CUISINE person.
+    # 4. /recap credits the helper (recap text is the 2nd-to-last call; /recap also sends a leaderboard message).
     await main.handler(_eventbridge_event("/recap@DrahmstrasseBot"), {})
-    recap_text = bot.bot.send_message.call_args[0][1]
+    recap_text = bot.bot.send_message.call_args_list[-2][0][1]
     assert f"frigo fait par {helper}" in recap_text
     assert f"(pas {cuisine_person})" in recap_text
 
@@ -201,12 +201,11 @@ async def test_plandetravail_counter_write_path_round_trip(bot):
     assert sub_data["count"] == 2
     assert sub_data["doers"] == {"Timon", "Léa"}
 
-    # 4. /recap credits both Timon and Léa for "plan de travail", not just
-    # whoever pressed "+1" last.
+    # 4. /recap credits both Timon and Léa, not just whoever pressed "+1" last (recap text is the 2nd-to-last call; /recap also sends a leaderboard message).
     assignments = menage.get_role_assignments(colocataires)
     cuisine_person = assignments["CUISINE"]
     await main.handler(_eventbridge_event("/recap@DrahmstrasseBot"), {})
-    recap_text = bot.bot.send_message.call_args[0][1]
+    recap_text = bot.bot.send_message.call_args_list[-2][0][1]
     if cuisine_person == "Timon":
         assert "plan de travail fait par Léa" in recap_text
     elif cuisine_person == "Léa":

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -211,6 +211,45 @@ def test_get_last_watered_date_picks_most_recent(mock_dt, mock_get_table):
 
 
 @patch("src.plants._get_table")
+def test_get_watering_totals_counts_watered_days_per_person(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {"week_key": "plant:2026-06-01", "watering": {"state": "watered", "by": "Léa"}},
+            {"week_key": "plant:2026-06-02", "watering": {"state": "watered", "by": "Alexis"}},
+            {"week_key": "plant:2026-06-03", "watering": {"state": "watered", "by": "Léa"}},
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    assert plants.get_watering_totals() == {"Léa": 2, "Alexis": 1}
+
+
+@patch("src.plants._get_table")
+def test_get_watering_totals_ignores_unwatered_and_non_plant_rows(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {
+        "Items": [
+            {"week_key": "plant:2026-06-01", "watering": {"state": "ok", "by": "Timon"}},
+            {"week_key": "plant:2026-06-02", "watering": {}},
+            {"week_key": "2026-W14", "completed": {"CUISINE": {"by": "Timon", "at": "..."}}},
+        ]
+    }
+    mock_get_table.return_value = mock_table
+
+    assert plants.get_watering_totals() == {}
+
+
+@patch("src.plants._get_table")
+def test_get_watering_totals_empty_table(mock_get_table):
+    mock_table = MagicMock()
+    mock_table.scan.return_value = {"Items": []}
+    mock_get_table.return_value = mock_table
+
+    assert plants.get_watering_totals() == {}
+
+
+@patch("src.plants._get_table")
 @patch("src.plants.datetime")
 def test_get_last_watered_date_respects_lookback(mock_dt, mock_get_table):
     """Rows older than lookback_days are ignored."""


### PR DESCRIPTION
- chores._aggregate_completions() is the single place that scans the chores table and buckets every completion by person, role, and (role, subtask)
- /stats (dev-chat only, unchanged gating) is now exhaustive: per-person, per-role, and per-subtask breakdowns
- /leaderboard (new, public) shows only positive highlights from the same aggregation
- /done folds a cendrier row/line into a smoker's own message (cendrier.is_smoker) instead of a separate message, reusing _build_cendrier_text and a shared _resolve_and_toggle_cendrier helper for both the standalone /cendrier button and the new donecendrier: row.
- menage.ROLE_EMOJIS is now the single source of truth for role emoji, used by both menage.getRoles() and chores.py.